### PR TITLE
fix: use proper URLs for discord avatars

### DIFF
--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -26,11 +26,12 @@ export interface DiscordMessageOptions {
 }
 
 export const defaultDiscordAvatars: Omit<Avatars, 'default'> = {
-	blue: 'https://cdn.discordapp.com/attachments/654503812593090602/665721745466195978/blue.png',
-	gray: 'https://cdn.discordapp.com/attachments/654503812593090602/665721746569166849/gray.png',
-	green: 'https://cdn.discordapp.com/attachments/654503812593090602/665721748431306753/green.png',
-	orange: 'https://cdn.discordapp.com/attachments/654503812593090602/665721750201434138/orange.png',
-	red: 'https://cdn.discordapp.com/attachments/654503812593090602/665721752277483540/red.png'
+	blue: 'https://cdn.discordapp.com/embed/avatars/0.png',
+	gray: 'https://cdn.discordapp.com/embed/avatars/1.png',
+	green: 'https://cdn.discordapp.com/embed/avatars/2.png',
+	orange: 'https://cdn.discordapp.com/embed/avatars/3.png',
+	red: 'https://cdn.discordapp.com/embed/avatars/4.png',
+        pink: 'https://cdn.discordapp.com/embed/avatars/5.png'
 };
 
 const globalAvatars: Avatars = window.$discordMessage?.avatars ?? ({} as Avatars);

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -31,7 +31,7 @@ export const defaultDiscordAvatars: Omit<Avatars, 'default'> = {
 	green: 'https://cdn.discordapp.com/embed/avatars/2.png',
 	orange: 'https://cdn.discordapp.com/embed/avatars/3.png',
 	red: 'https://cdn.discordapp.com/embed/avatars/4.png',
-        pink: 'https://cdn.discordapp.com/embed/avatars/5.png'
+	pink: 'https://cdn.discordapp.com/embed/avatars/5.png'
 };
 
 const globalAvatars: Avatars = window.$discordMessage?.avatars ?? ({} as Avatars);


### PR DESCRIPTION
Instead of using attachments to upload the image's avatar, you can use Discord's own `embed/avatar`.

If someone deletes the images, they will soon not be able to be seen by embed.