### PR TITLE
fix(discord-command): remove prepending slash in names

### DIFF
--- a/packages/core/src/components/discord-command/discord-command.tsx
+++ b/packages/core/src/components/discord-command/discord-command.tsx
@@ -72,7 +72,7 @@ export class DiscordCommand implements ComponentInterface {
 					{profile.author}
 				</span>
 				{' used '}
-				<div class="discord-replied-message-content discord-command-name">{`/${this.command}`}</div>
+				<div class="discord-replied-message-content discord-command-name">{this.command}</div>
 			</Host>
 		);
 	}

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -233,7 +233,7 @@
 				<h3 class="title">Commands</h3>
 				<discord-messages>
 					<discord-message profile="skyra">
-						<discord-command slot="reply" profile="favna" command="ping"></discord-command>
+						<discord-command slot="reply" profile="favna" command="/ping"></discord-command>
 						Pong!
 					</discord-message>
 					<discord-message profile="skyra">
@@ -244,7 +244,7 @@
 				<h3 class="title">Commands in Compact Mode</h3>
 				<discord-messages compact-mode>
 					<discord-message profile="skyra">
-						<discord-command slot="reply" profile="favna" command="ping"></discord-command>
+						<discord-command slot="reply" profile="favna" command="/ping"></discord-command>
 						Pong!
 					</discord-message>
 					<discord-message profile="skyra">


### PR DESCRIPTION
Small change, removes the `/` from `<discord-command>` since context menu commands don't have this