### PR TITLE
feat: add `discord-tenor-video` component

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -348,6 +348,24 @@ export namespace Components {
          */
         "type": 'join' | 'leave' | 'call' | 'missed-call' | 'boost' | 'edit' | 'thread' | 'alert' | 'error';
     }
+    interface DiscordTenorVideo {
+        /**
+          * The height of the video in pixels
+         */
+        "height": number;
+        /**
+          * The URL for the video thumbnail
+         */
+        "thumbnail": string;
+        /**
+          * The URL for the video
+         */
+        "url": string;
+        /**
+          * The width of the video in pixels
+         */
+        "width": number;
+    }
 }
 declare global {
     interface HTMLDiscordActionRowElement extends Components.DiscordActionRow, HTMLStencilElement {
@@ -446,6 +464,12 @@ declare global {
         prototype: HTMLDiscordSystemMessageElement;
         new (): HTMLDiscordSystemMessageElement;
     };
+    interface HTMLDiscordTenorVideoElement extends Components.DiscordTenorVideo, HTMLStencilElement {
+    }
+    var HTMLDiscordTenorVideoElement: {
+        prototype: HTMLDiscordTenorVideoElement;
+        new (): HTMLDiscordTenorVideoElement;
+    };
     interface HTMLElementTagNameMap {
         "discord-action-row": HTMLDiscordActionRowElement;
         "discord-attachment": HTMLDiscordAttachmentElement;
@@ -463,6 +487,7 @@ declare global {
         "discord-reactions": HTMLDiscordReactionsElement;
         "discord-reply": HTMLDiscordReplyElement;
         "discord-system-message": HTMLDiscordSystemMessageElement;
+        "discord-tenor-video": HTMLDiscordTenorVideoElement;
     }
 }
 declare namespace LocalJSX {
@@ -807,6 +832,24 @@ declare namespace LocalJSX {
          */
         "type"?: 'join' | 'leave' | 'call' | 'missed-call' | 'boost' | 'edit' | 'thread' | 'alert' | 'error';
     }
+    interface DiscordTenorVideo {
+        /**
+          * The height of the video in pixels
+         */
+        "height"?: number;
+        /**
+          * The URL for the video thumbnail
+         */
+        "thumbnail"?: string;
+        /**
+          * The URL for the video
+         */
+        "url"?: string;
+        /**
+          * The width of the video in pixels
+         */
+        "width"?: number;
+    }
     interface IntrinsicElements {
         "discord-action-row": DiscordActionRow;
         "discord-attachment": DiscordAttachment;
@@ -824,6 +867,7 @@ declare namespace LocalJSX {
         "discord-reactions": DiscordReactions;
         "discord-reply": DiscordReply;
         "discord-system-message": DiscordSystemMessage;
+        "discord-tenor-video": DiscordTenorVideo;
     }
 }
 export { LocalJSX as JSX };
@@ -846,6 +890,7 @@ declare module "@stencil/core" {
             "discord-reactions": LocalJSX.DiscordReactions & JSXBase.HTMLAttributes<HTMLDiscordReactionsElement>;
             "discord-reply": LocalJSX.DiscordReply & JSXBase.HTMLAttributes<HTMLDiscordReplyElement>;
             "discord-system-message": LocalJSX.DiscordSystemMessage & JSXBase.HTMLAttributes<HTMLDiscordSystemMessageElement>;
+            "discord-tenor-video": LocalJSX.DiscordTenorVideo & JSXBase.HTMLAttributes<HTMLDiscordTenorVideoElement>;
         }
     }
 }

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -354,10 +354,6 @@ export namespace Components {
          */
         "height": number;
         /**
-          * The URL for the video thumbnail
-         */
-        "thumbnail": string;
-        /**
           * The URL for the video
          */
         "url": string;
@@ -837,10 +833,6 @@ declare namespace LocalJSX {
           * The height of the video in pixels
          */
         "height"?: number;
-        /**
-          * The URL for the video thumbnail
-         */
-        "thumbnail"?: string;
         /**
           * The URL for the video
          */

--- a/packages/core/src/components/discord-tenor-video/discord-tenor-video.css
+++ b/packages/core/src/components/discord-tenor-video/discord-tenor-video.css
@@ -18,7 +18,7 @@
 	border-radius: 4px;
 }
 
-.discord-tenor-video .discord-tenor-video-wrapper video{
+.discord-tenor-video .discord-tenor-video-wrapper video {
 	-webkit-box-align: center;
 	-webkit-box-pack: center;
 	align-items: center;

--- a/packages/core/src/components/discord-tenor-video/discord-tenor-video.css
+++ b/packages/core/src/components/discord-tenor-video/discord-tenor-video.css
@@ -1,0 +1,35 @@
+.discord-tenor-video {
+	color: #dcddde;
+	display: flex;
+	font-size: 13px;
+	line-height: 150%;
+	margin-bottom: 8px;
+	margin-top: 8px;
+}
+
+.discord-tenor-video .discord-tenor-video-wrapper {
+	display: block;
+	position: relative;
+	-webkit-user-select: text;
+	-moz-user-select: text;
+	-ms-user-select: text;
+	user-select: text;
+	overflow: hidden;
+	border-radius: 4px;
+}
+
+.discord-tenor-video .discord-tenor-video-wrapper video{
+	-webkit-box-align: center;
+	-webkit-box-pack: center;
+	align-items: center;
+	border-radius: 0;
+	cursor: pointer;
+	display: flex;
+	height: 100%;
+	justify-content: center;
+	max-height: 100%;
+	width: 100%;
+
+	left: 0px;
+	top: 0px;
+}

--- a/packages/core/src/components/discord-tenor-video/discord-tenor-video.css
+++ b/packages/core/src/components/discord-tenor-video/discord-tenor-video.css
@@ -29,7 +29,6 @@
 	justify-content: center;
 	max-height: 100%;
 	width: 100%;
-
 	left: 0px;
 	top: 0px;
 }

--- a/packages/core/src/components/discord-tenor-video/discord-tenor-video.tsx
+++ b/packages/core/src/components/discord-tenor-video/discord-tenor-video.tsx
@@ -1,0 +1,41 @@
+import { Component, ComponentInterface, Element, h, Host, Prop } from '@stencil/core';
+
+@Component({
+	tag: 'discord-tenor-video',
+	styleUrl: 'discord-tenor-video.css'
+})
+export class DiscordTenorVideo implements ComponentInterface {
+	/**
+	 * The DiscordTenorVideo element.
+	 */
+	@Element()
+	public el: HTMLElement;
+
+	/**
+	 * The URL for the video
+	 */
+	@Prop()
+	public url: string;
+
+	/**
+	 * The height of the video in pixels
+	 */
+	@Prop()
+	public height: number;
+
+	/**
+	 * The width of the video in pixels
+	 */
+	@Prop()
+	public width: number;
+
+	public render() {
+		return (
+			<Host class="discord-tenor-video">
+				<div class="discord-tenor-video-wrapper" style={{ height: `${this.height}px`, width: `${this.width}px` }}>
+					<video muted preload="auto" autoplay loop src={this.url} height={this.height} width={this.width}></video>
+				</div>
+			</Host>
+		);
+	}
+}

--- a/packages/core/src/components/discord-tenor-video/readme.md
+++ b/packages/core/src/components/discord-tenor-video/readme.md
@@ -1,0 +1,16 @@
+# discord-attachment
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property | Attribute | Description                                               | Type     | Default                |
+| -------- | --------- | --------------------------------------------------------- | -------- | ---------------------- |
+| `alt`    | `alt`     | The alt text to show in case the image was unable to load | `string` | `'discord attachment'` |
+| `height` | `height`  | The height of the image in pixels                         | `number` | `undefined`            |
+| `url`    | `url`     | The URL for the image attachment                          | `string` | `undefined`            |
+| `width`  | `width`   | The width of the image in pixels                          | `number` | `undefined`            |
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/core/src/components/discord-tenor-video/readme.md
+++ b/packages/core/src/components/discord-tenor-video/readme.md
@@ -4,12 +4,11 @@
 
 ## Properties
 
-| Property | Attribute | Description                                               | Type     | Default                |
-| -------- | --------- | --------------------------------------------------------- | -------- | ---------------------- |
-| `alt`    | `alt`     | The alt text to show in case the image was unable to load | `string` | `'discord attachment'` |
-| `height` | `height`  | The height of the image in pixels                         | `number` | `undefined`            |
-| `url`    | `url`     | The URL for the image attachment                          | `string` | `undefined`            |
-| `width`  | `width`   | The width of the image in pixels                          | `number` | `undefined`            |
+| Property | Attribute | Description                       | Type     | Default     |
+| -------- | --------- | --------------------------------- | -------- | ----------- |
+| `height` | `height`  | The height of the video in pixels | `number` | `undefined` |
+| `url`    | `url`     | The URL for the video             | `string` | `undefined` |
+| `width`  | `width`   | The width of the video in pixels  | `number` | `undefined` |
 
 ---
 

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -129,6 +129,39 @@
 						<discord-mention highlight>Maximillian Osborn</discord-mention>, thanks! I will!
 					</discord-message>
 				</discord-messages>
+				<h3 class="title">Server Invites</h3>
+				<discord-messages>
+					<discord-message profile="favna">
+						discord.gg/djs <br />
+						discord.gg/code <br />
+						discord.gg/6gakFR2
+						<discord-attachments slot="attachments">
+							<discord-invite
+								name="discord.js - Imagine a bot"
+								icon="/static/discordjs.png"
+								url="https://discord.gg/djs"
+								online="16417"
+								members="87147"
+								verified="true"
+							></discord-invite>
+							<discord-invite
+								name="The Coding Den"
+								icon="/static/tcd.png"
+								url="https://discord.gg/code"
+								online="18456"
+								members="73548"
+								partnered="true"
+							></discord-invite>
+							<discord-invite
+								name="Skyra Lounge"
+								url="https://join.skyra.pw"
+								icon="/static/skyralounge.gif"
+								online="176"
+								members="738"
+							></discord-invite>
+						</discord-attachments>
+					</discord-message>
+				</discord-messages>
 				<h3 class="title">Image Attachments with small images</h3>
 				<discord-messages>
 					<discord-message profile="Alyx Vargas">
@@ -169,33 +202,6 @@
 					</discord-system-message>
 					<discord-system-message type="missed-call"> You missed a call from <i>Favna</i> that lasted a minute. </discord-system-message>
 					<discord-system-message type="leave"> <i>Favna</i> left the group. </discord-system-message>
-				</discord-messages>
-				<h3 class="title">Server Invites</h3>
-				<discord-messages>
-					<discord-message profile="favna">
-						discord.gg/djs <br />
-						discord.gg/code <br />
-						discord.gg/6gakFR2
-						<discord-attachments slot="attachments">
-							<discord-invite
-								name="discord.js - Imagine a bot"
-								icon="/static/discordjs.png"
-								url="https://discord.gg/djs"
-								online="16417"
-								members="87147"
-								verified="true"
-							></discord-invite>
-							<discord-invite
-								name="The Coding Den"
-								icon="/static/tcd.png"
-								url="https://discord.gg/code"
-								online="18456"
-								members="73548"
-								partnered="true"
-							></discord-invite>
-							<discord-invite name="Skyra Lounge" url="https://join.skyra.pw" online="176" members="738"></discord-invite>
-						</discord-attachments>
-					</discord-message>
 				</discord-messages>
 				<h3 class="title">Reactions</h3>
 				<discord-messages>
@@ -396,6 +402,15 @@
 						</discord-embed>
 					</discord-message>
 				</discord-messages>
+				<h3 class="title">A tenor-gif in video format</h3>
+				<discord-messages>
+					<discord-message profile="maximillian">
+						<discord-tenor-video
+							slot="attachments"
+							url="https://c.tenor.com/oTeBa4EVepMAAAPo/business-cat-working.mp4"
+						/>
+					</discord-message>
+				</discord-messages>
 				<h3 class="title">Inline fields</h3>
 				<discord-messages>
 					<discord-message profile="skyra">
@@ -418,50 +433,6 @@
 								<discord-embed-field field-title="Inline field title" inline inline-index="3"> Some value here </discord-embed-field>
 							</discord-embed-fields>
 						</discord-embed>
-					</discord-message>
-				</discord-messages>
-				<h3 class="title">Attachments and invites</h3>
-				<discord-messages>
-					<discord-message profile="favna">
-						discord.gg/djs <br />
-						discord.gg/code <br />
-						discord.gg/6gakFR2
-						<discord-attachments slot="attachments">
-							<discord-invite
-								name="discord.js - Imagine a bot"
-								icon="/static/discordjs.png"
-								url="https://discord.gg/djs"
-								online="16417"
-								members="87147"
-								verified="true"
-							></discord-invite>
-							<discord-invite
-								name="The Coding Den"
-								icon="/static/tcd.png"
-								url="https://discord.gg/code"
-								online="18456"
-								members="73548"
-								partnered="true"
-							></discord-invite>
-							<discord-invite
-								name="Skyra Lounge"
-								url="https://join.skyra.pw"
-								icon="/static/skyralounge.gif"
-								online="176"
-								members="738"
-							></discord-invite>
-						</discord-attachments>
-					</discord-message>
-				</discord-messages>
-
-				<h3 class="title">A tenor-gif in video format</h3>
-				<discord-messages>
-					<discord-message profile="maximillian">
-						<discord-tenor-video
-							slot="attachments"
-							url="https://media.tenor.co/videos/0c5039806690ee8a9d4f86690c7e106f/mp4"
-							height="200"
-						/>
 					</discord-message>
 				</discord-messages>
 			</main>

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -453,6 +453,14 @@
 						</discord-attachments>
 					</discord-message>
 				</discord-messages>
+
+
+				<h3 class="title">A tenor-gif in video format</h3>
+				<discord-messages>
+					<discord-message profile="maximillian">
+						<discord-tenor-video slot="attachments" url="https://media.tenor.co/videos/0c5039806690ee8a9d4f86690c7e106f/mp4" height="200" />
+					</discord-message>
+				</discord-messages>
 			</main>
 		</div>
 	</body>

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -454,11 +454,14 @@
 					</discord-message>
 				</discord-messages>
 
-
 				<h3 class="title">A tenor-gif in video format</h3>
 				<discord-messages>
 					<discord-message profile="maximillian">
-						<discord-tenor-video slot="attachments" url="https://media.tenor.co/videos/0c5039806690ee8a9d4f86690c7e106f/mp4" height="200" />
+						<discord-tenor-video
+							slot="attachments"
+							url="https://media.tenor.co/videos/0c5039806690ee8a9d4f86690c7e106f/mp4"
+							height="200"
+						/>
 					</discord-message>
 				</discord-messages>
 			</main>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,3 +26,4 @@ export const DiscordReply = /*@__PURE__*/ createReactComponent<JSX.DiscordReply,
 export const DiscordSystemMessage = /*@__PURE__*/ createReactComponent<JSX.DiscordSystemMessage, HTMLDiscordSystemMessageElement>(
 	'discord-system-message'
 );
+export const DiscordTenorVideo = /*@__PURE__*/ createReactComponent<JSX.DiscordTenorVideo, HTMLDiscordTenorVideoElement>('discord-tenor-video');


### PR DESCRIPTION
I added a \<discord-tenor-video\> tag to play tenor gifs in video format (autoplayed looped no-control) (since discord API sends them as video embed and thats how their client renders it)
The styling is similar to discord-attachment and uses the attachment slot
Relevant to [this issue](https://github.com/skyra-project/discord-components/issues/126)

The changes in commit `57c26ad` are auto generated through `yarn build`