### PR TITLE
feat: Thread Accessories

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -362,6 +362,55 @@ export namespace Components {
          */
         "width": number;
     }
+    interface DiscordThread {
+        /**
+          * The the text within the call to action text. (i.e. 'See Thread' or 'x Messages')
+         */
+        "cta": string;
+        /**
+          * The name of the thread.
+         */
+        "name": string;
+    }
+    interface DiscordThreadMessage {
+        /**
+          * The message author's username.
+          * @default 'User'
+         */
+        "author": string;
+        /**
+          * The message author's avatar. Can be an avatar shortcut, relative path, or external link.
+         */
+        "avatar": string;
+        /**
+          * Whether the message author is a bot or not. Only works if `server` is `false` or `undefined`.
+         */
+        "bot": boolean;
+        /**
+          * Whether the message has been edited or not.
+         */
+        "edited": boolean;
+        /**
+          * The id of the profile data to use.
+         */
+        "profile": string;
+        /**
+          * The relative timestamp of the message.
+         */
+        "relativeTimestamp": string;
+        /**
+          * The message author's primary role color. Can be any [CSS color value](https://www.w3schools.com/cssref/css_colors_legal.asp).
+         */
+        "roleColor": string;
+        /**
+          * Whether the message author is a server crosspost webhook or not. Only works if `bot` is `false` or `undefined`.
+         */
+        "server": boolean;
+        /**
+          * Whether the bot is verified or not. Only works if `bot` is `true`
+         */
+        "verified": boolean;
+    }
 }
 declare global {
     interface HTMLDiscordActionRowElement extends Components.DiscordActionRow, HTMLStencilElement {
@@ -466,6 +515,18 @@ declare global {
         prototype: HTMLDiscordTenorVideoElement;
         new (): HTMLDiscordTenorVideoElement;
     };
+    interface HTMLDiscordThreadElement extends Components.DiscordThread, HTMLStencilElement {
+    }
+    var HTMLDiscordThreadElement: {
+        prototype: HTMLDiscordThreadElement;
+        new (): HTMLDiscordThreadElement;
+    };
+    interface HTMLDiscordThreadMessageElement extends Components.DiscordThreadMessage, HTMLStencilElement {
+    }
+    var HTMLDiscordThreadMessageElement: {
+        prototype: HTMLDiscordThreadMessageElement;
+        new (): HTMLDiscordThreadMessageElement;
+    };
     interface HTMLElementTagNameMap {
         "discord-action-row": HTMLDiscordActionRowElement;
         "discord-attachment": HTMLDiscordAttachmentElement;
@@ -484,6 +545,8 @@ declare global {
         "discord-reply": HTMLDiscordReplyElement;
         "discord-system-message": HTMLDiscordSystemMessageElement;
         "discord-tenor-video": HTMLDiscordTenorVideoElement;
+        "discord-thread": HTMLDiscordThreadElement;
+        "discord-thread-message": HTMLDiscordThreadMessageElement;
     }
 }
 declare namespace LocalJSX {
@@ -842,6 +905,55 @@ declare namespace LocalJSX {
          */
         "width"?: number;
     }
+    interface DiscordThread {
+        /**
+          * The the text within the call to action text. (i.e. 'See Thread' or 'x Messages')
+         */
+        "cta"?: string;
+        /**
+          * The name of the thread.
+         */
+        "name"?: string;
+    }
+    interface DiscordThreadMessage {
+        /**
+          * The message author's username.
+          * @default 'User'
+         */
+        "author"?: string;
+        /**
+          * The message author's avatar. Can be an avatar shortcut, relative path, or external link.
+         */
+        "avatar"?: string;
+        /**
+          * Whether the message author is a bot or not. Only works if `server` is `false` or `undefined`.
+         */
+        "bot"?: boolean;
+        /**
+          * Whether the message has been edited or not.
+         */
+        "edited"?: boolean;
+        /**
+          * The id of the profile data to use.
+         */
+        "profile"?: string;
+        /**
+          * The relative timestamp of the message.
+         */
+        "relativeTimestamp"?: string;
+        /**
+          * The message author's primary role color. Can be any [CSS color value](https://www.w3schools.com/cssref/css_colors_legal.asp).
+         */
+        "roleColor"?: string;
+        /**
+          * Whether the message author is a server crosspost webhook or not. Only works if `bot` is `false` or `undefined`.
+         */
+        "server"?: boolean;
+        /**
+          * Whether the bot is verified or not. Only works if `bot` is `true`
+         */
+        "verified"?: boolean;
+    }
     interface IntrinsicElements {
         "discord-action-row": DiscordActionRow;
         "discord-attachment": DiscordAttachment;
@@ -860,6 +972,8 @@ declare namespace LocalJSX {
         "discord-reply": DiscordReply;
         "discord-system-message": DiscordSystemMessage;
         "discord-tenor-video": DiscordTenorVideo;
+        "discord-thread": DiscordThread;
+        "discord-thread-message": DiscordThreadMessage;
     }
 }
 export { LocalJSX as JSX };
@@ -883,6 +997,8 @@ declare module "@stencil/core" {
             "discord-reply": LocalJSX.DiscordReply & JSXBase.HTMLAttributes<HTMLDiscordReplyElement>;
             "discord-system-message": LocalJSX.DiscordSystemMessage & JSXBase.HTMLAttributes<HTMLDiscordSystemMessageElement>;
             "discord-tenor-video": LocalJSX.DiscordTenorVideo & JSXBase.HTMLAttributes<HTMLDiscordTenorVideoElement>;
+            "discord-thread": LocalJSX.DiscordThread & JSXBase.HTMLAttributes<HTMLDiscordThreadElement>;
+            "discord-thread-message": LocalJSX.DiscordThreadMessage & JSXBase.HTMLAttributes<HTMLDiscordThreadMessageElement>;
         }
     }
 }

--- a/packages/core/src/components/author-info/author-info.css
+++ b/packages/core/src/components/author-info/author-info.css
@@ -16,7 +16,7 @@
 }
 
 .discord-message .discord-author-info .discord-application-tag {
-	background-color: hsl(235, 85.6%, 64.7%);
+	background-color: #5865f2;
 	color: #fff;
 	font-size: 0.65em;
 	margin-left: 5px;
@@ -38,10 +38,6 @@
 	width: 0.9375rem;
 	height: 0.9375rem;
 	margin-left: -0.25rem;
-}
-
-.discord-light-theme .discord-message .discord-author-info .discord-application-tag {
-	color: #fff;
 }
 
 .discord-compact-mode .discord-message .discord-author-info .discord-author-username {

--- a/packages/core/src/components/discord-message/discord-message.css
+++ b/packages/core/src/components/discord-message/discord-message.css
@@ -76,6 +76,7 @@
 	margin-right: 16px;
 	margin-top: 5px;
 	min-width: 40px;
+	z-index: 1;
 }
 
 .discord-message .discord-author-avatar img {
@@ -189,6 +190,22 @@
 
 .discord-light-theme .discord-message:hover {
 	background-color: rgba(6, 6, 7, 0.02);
+}
+
+.discord-message.discord-message-has-thread:after {
+	width: 2rem;
+	left: 2.2rem;
+	top: 1.75rem;
+	border-left: 2px solid #4f545c;
+	border-bottom: 2px solid #4f545c;
+	border-bottom-left-radius: 8px;
+	bottom: 29px;
+	content: '';
+	position: absolute;
+}
+
+.discord-light-theme .discord-message.discord-message-has-thread:after {
+	border-color: #747f8d;
 }
 
 @import '../author-info/author-info.css';

--- a/packages/core/src/components/discord-message/discord-message.tsx
+++ b/packages/core/src/components/discord-message/discord-message.tsx
@@ -116,8 +116,14 @@ export class DiscordMessage implements ComponentInterface {
 				return child.tagName.toLowerCase() === 'discord-mention' && child.highlight && ['user', 'role'].includes(child.type);
 			}) || this.highlight;
 
+		const hasThread: boolean =
+			// @ts-expect-error ts doesn't understand this
+			Array.from(this.el.children).some((child: HTMLDiscordThreadElement): boolean => {
+				return child.tagName.toLowerCase() === 'discord-thread';
+			});
+
 		return (
-			<Host class={clsx('discord-message', { 'discord-highlight-mention': highlightMention })}>
+			<Host class={clsx('discord-message', { 'discord-highlight-mention': highlightMention, 'discord-message-has-thread': hasThread })}>
 				<slot name="reply"></slot>
 				<div class="discord-message-inner">
 					{parent.compactMode && <span class="discord-message-timestamp">{this.timestamp}</span>}
@@ -159,6 +165,7 @@ export class DiscordMessage implements ComponentInterface {
 							<slot name="attachments"></slot>
 							<slot name="components"></slot>
 							<slot name="reactions"></slot>
+							<slot name="thread"></slot>
 						</div>
 					</div>
 				</div>

--- a/packages/core/src/components/discord-system-message/discord-system-message.css
+++ b/packages/core/src/components/discord-system-message/discord-system-message.css
@@ -120,4 +120,20 @@
 	background-color: rgba(6, 6, 7, 0.02);
 }
 
+.discord-system-message.discord-system-message-has-thread:after {
+	width: 2rem;
+	left: 2.2rem;
+	top: 1.75rem;
+	border-left: 2px solid #4f545c;
+	border-bottom: 2px solid #4f545c;
+	border-bottom-left-radius: 8px;
+	bottom: 29px;
+	content: '';
+	position: absolute;
+}
+
+.discord-light-theme .discord-system-message.discord-system-message-has-thread:after {
+	border-color: #747f8d;
+}
+
 @import '../author-info/author-info.css';

--- a/packages/core/src/components/discord-system-message/discord-system-message.tsx
+++ b/packages/core/src/components/discord-system-message/discord-system-message.tsx
@@ -100,8 +100,19 @@ export class DiscordSystemMessage implements ComponentInterface {
 				break;
 		}
 
+		const hasThread: boolean =
+			// @ts-expect-error ts doesn't understand this
+			Array.from(this.el.children).some((child: HTMLDiscordThreadElement): boolean => {
+				return child.tagName.toLowerCase() === 'discord-thread';
+			});
+
 		return (
-			<Host class={clsx('discord-system-message', `discord-${this.type}-system-message`, { 'discord-channel-name-change': this.channelName })}>
+			<Host
+				class={clsx('discord-system-message', `discord-${this.type}-system-message`, {
+					'discord-system-message-has-thread': hasThread,
+					'discord-channel-name-change': this.channelName
+				})}
+			>
 				<div class="discord-message-icon">{icon}</div>
 				<div class="discord-message-content">
 					<span>
@@ -109,6 +120,7 @@ export class DiscordSystemMessage implements ComponentInterface {
 						<span class="discord-message-timestamp">{this.timestamp}</span>
 					</span>
 					<slot name="reactions"></slot>
+					<slot name="thread"></slot>
 				</div>
 			</Host>
 		);

--- a/packages/core/src/components/discord-thread-message/discord-thread-message.css
+++ b/packages/core/src/components/discord-thread-message/discord-thread-message.css
@@ -1,0 +1,81 @@
+.discord-thread-message {
+	height: 18px;
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	font-size: 0.875rem;
+	line-height: 1.125rem;
+}
+
+.discord-thread-message .discord-thread-message-avatar {
+	margin-right: 8px;
+	flex: 0 0 auto;
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	user-select: none;
+}
+
+.discord-thread-message .discord-thread-message-username {
+	flex-shrink: 0;
+	font-size: inherit;
+	line-height: inherit;
+	margin-right: 0.25rem;
+	opacity: 0.64;
+	color: white;
+	display: inline;
+	vertical-align: baseline;
+	position: relative;
+	overflow: hidden;
+}
+
+.discord-light-theme .discord-thread-message .discord-thread-message-username {
+	color: #060607;
+}
+
+.discord-thread-message .discord-application-tag {
+	background-color: #5865f2;
+	color: #fff;
+	font-size: 0.65em;
+	margin-right: 5px;
+	border-radius: 3px;
+	line-height: 100%;
+	text-transform: uppercase;
+	display: flex;
+	align-items: center;
+	height: 0.9375rem;
+	padding: 0 0.275rem;
+	margin-top: 0.075em;
+	border-radius: 0.1875rem;
+}
+
+.discord-thread-message .discord-application-tag-verified {
+	display: inline-block;
+	width: 0.9375rem;
+	height: 0.9375rem;
+	margin-left: -0.25rem;
+}
+
+.discord-thread-message .discord-thread-message-content {
+	display: flex;
+	align-items: baseline;
+}
+
+.discord-thread-message .discord-message-edited {
+	color: #72767d;
+	font-size: 10px;
+	margin-left: 5px;
+}
+
+.discord-thread-message .discord-thread-message-timestamp {
+	color: #72767d;
+	flex-shrink: 0;
+	margin-left: 8px;
+	font-size: 0.875rem;
+	line-height: 1.125rem;
+}
+
+.discord-light-theme .discord-thread-message .discord-thread-message-timestamp,
+.discord-light-theme .discord-thread-message .discord-message-edited {
+	color: #747f8d;
+}

--- a/packages/core/src/components/discord-thread-message/discord-thread-message.tsx
+++ b/packages/core/src/components/discord-thread-message/discord-thread-message.tsx
@@ -1,0 +1,105 @@
+import { Component, ComponentInterface, Element, h, Host, Prop } from '@stencil/core';
+import Fragment from '../../Fragment';
+import { avatars, Profile, profiles } from '../../options';
+import VerifiedTick from '../svgs/verified-tick';
+
+@Component({
+	tag: 'discord-thread-message',
+	styleUrl: 'discord-thread-message.css'
+})
+export class DiscordThreadMessage implements ComponentInterface {
+	/**
+	 * The DiscordThreadMessage element.
+	 */
+	@Element()
+	public el: HTMLElement;
+
+	/**
+	 * The id of the profile data to use.
+	 */
+	@Prop()
+	public profile: string;
+
+	/**
+	 * The message author's username.
+	 * @default 'User'
+	 */
+	@Prop()
+	public author = 'User';
+
+	/**
+	 * The message author's avatar. Can be an avatar shortcut, relative path, or external link.
+	 */
+	@Prop()
+	public avatar: string;
+
+	/**
+	 * Whether the message author is a bot or not.
+	 * Only works if `server` is `false` or `undefined`.
+	 */
+	@Prop()
+	public bot = false;
+
+	/**
+	 * Whether the message author is a server crosspost webhook or not.
+	 * Only works if `bot` is `false` or `undefined`.
+	 */
+	@Prop()
+	public server = false;
+
+	/**
+	 * Whether the bot is verified or not.
+	 * Only works if `bot` is `true`
+	 */
+	@Prop()
+	public verified = false;
+
+	/**
+	 * Whether the message has been edited or not.
+	 */
+	@Prop()
+	public edited = false;
+
+	/**
+	 * The message author's primary role color. Can be any [CSS color value](https://www.w3schools.com/cssref/css_colors_legal.asp).
+	 */
+	@Prop()
+	public roleColor: string;
+
+	/**
+	 * The relative timestamp of the message.
+	 */
+	@Prop()
+	public relativeTimestamp = '1m ago';
+
+	public render() {
+		const resolveAvatar = (avatar: string): string => avatars[avatar] ?? avatar ?? avatars.default;
+
+		const defaultData: Profile = { author: this.author, bot: this.bot, verified: this.verified, server: this.server, roleColor: this.roleColor };
+		const profileData: Profile = Reflect.get(profiles, this.profile) ?? {};
+		const profile: Profile = { ...defaultData, ...profileData, ...{ avatar: resolveAvatar(profileData.avatar ?? this.avatar) } };
+
+		return (
+			<Host class="discord-thread-message">
+				<img src={profile.avatar} class="discord-thread-message-avatar" alt={profile.author} />
+				<Fragment>
+					{profile.bot && !profile.server && (
+						<span class="discord-application-tag">
+							{profile.verified && <VerifiedTick />}
+							Bot
+						</span>
+					)}
+					{profile.server && !profile.bot && <span class="discord-application-tag">Server</span>}
+				</Fragment>
+				<span class="discord-thread-message-username" style={{ color: profile.roleColor }}>
+					{profile.author}
+				</span>
+				<div class="discord-thread-message-content">
+					<slot />
+					{this.edited ? <span class="discord-message-edited">(edited)</span> : ''}
+				</div>
+				<span class="discord-thread-message-timestamp">{this.relativeTimestamp}</span>
+			</Host>
+		);
+	}
+}

--- a/packages/core/src/components/discord-thread-message/readme.md
+++ b/packages/core/src/components/discord-thread-message/readme.md
@@ -1,0 +1,21 @@
+# discord-thread-message
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property            | Attribute            | Description                                                                                                                   | Type      | Default     |
+| ------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `author`            | `author`             | The message author's username.                                                                                                | `string`  | `'User'`    |
+| `avatar`            | `avatar`             | The message author's avatar. Can be an avatar shortcut, relative path, or external link.                                      | `string`  | `undefined` |
+| `bot`               | `bot`                | Whether the message author is a bot or not. Only works if `server` is `false` or `undefined`.                                 | `boolean` | `false`     |
+| `edited`            | `edited`             | Whether the message has been edited or not.                                                                                   | `boolean` | `false`     |
+| `profile`           | `profile`            | The id of the profile data to use.                                                                                            | `string`  | `undefined` |
+| `relativeTimestamp` | `relative-timestamp` | The relative timestamp of the message.                                                                                        | `string`  | `'1m ago'`  |
+| `roleColor`         | `role-color`         | The message author's primary role color. Can be any [CSS color value](https://www.w3schools.com/cssref/css_colors_legal.asp). | `string`  | `undefined` |
+| `server`            | `server`             | Whether the message author is a server crosspost webhook or not. Only works if `bot` is `false` or `undefined`.               | `boolean` | `false`     |
+| `verified`          | `verified`           | Whether the bot is verified or not. Only works if `bot` is `true`                                                             | `boolean` | `false`     |
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/core/src/components/discord-thread/discord-thread.css
+++ b/packages/core/src/components/discord-thread/discord-thread.css
@@ -1,0 +1,61 @@
+.discord-thread {
+	background-color: #2f3136;
+	border-radius: 4px;
+	cursor: pointer;
+	margin-top: 8px;
+	max-width: 480px;
+	min-width: 0;
+	padding: 8px;
+	display: inline-flex;
+	width: fit-content;
+	flex-direction: column;
+}
+
+.discord-light-theme .discord-thread {
+	background-color: #f2f3f5;
+}
+
+.discord-thread .discord-thread-top {
+	display: flex;
+}
+
+.discord-thread .discord-thread-bottom {
+	font-size: 0.875rem;
+	line-height: 1.125rem;
+	align-items: center;
+	color: #b9bbbe;
+	display: flex;
+	margin-top: 2px;
+	white-space: nowrap;
+}
+
+.discord-light-theme .discord-thread-bottom {
+	color: #4f5660;
+}
+
+.discord-thread .discord-thread-name {
+	font-size: 0.875rem;
+	font-weight: 600;
+	line-height: 1.125rem;
+	color: white;
+	margin-right: 8px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.discord-light-theme .discord-thread-name {
+	color: #060607;
+}
+
+.discord-thread .discord-thread-cta {
+	color: #00aff4;
+	flex-shrink: 0;
+	font-size: 0.875rem;
+	font-weight: 600;
+	line-height: 1.125rem;
+}
+
+.discord-thread:hover .discord-thread-cta {
+	text-decoration: underline;
+}

--- a/packages/core/src/components/discord-thread/discord-thread.tsx
+++ b/packages/core/src/components/discord-thread/discord-thread.tsx
@@ -1,0 +1,41 @@
+import { Component, ComponentInterface, Element, h, Host, Prop } from '@stencil/core';
+
+@Component({
+	tag: 'discord-thread',
+	styleUrl: 'discord-thread.css'
+})
+export class DiscordThread implements ComponentInterface {
+	/**
+	 * The DiscordThread element.
+	 */
+	@Element()
+	public el: HTMLElement;
+
+	/**
+	 * The name of the thread.
+	 */
+	@Prop()
+	public name = 'Thread';
+
+	/**
+	 * The the text within the call to action text. (i.e. 'See Thread' or 'x Messages')
+	 */
+	@Prop()
+	public cta = 'See Thread';
+
+	public render() {
+		return (
+			<Host class="discord-thread">
+				<div class="discord-thread-top">
+					<span class="discord-thread-name">{this.name}</span>
+					<span class="discord-thread-cta" aria-hidden="true">
+						{this.cta} ›
+					</span>
+				</div>
+				<span class="discord-thread-bottom">
+					<slot></slot>
+				</span>
+			</Host>
+		);
+	}
+}

--- a/packages/core/src/components/discord-thread/readme.md
+++ b/packages/core/src/components/discord-thread/readme.md
@@ -1,0 +1,14 @@
+# discord-thread
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property | Attribute | Description                                                                      | Type     | Default        |
+| -------- | --------- | -------------------------------------------------------------------------------- | -------- | -------------- |
+| `cta`    | `cta`     | The the text within the call to action text. (i.e. 'See Thread' or 'x Messages') | `string` | `'See Thread'` |
+| `name`   | `name`    | The name of the thread.                                                          | `string` | `'Thread'`     |
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -203,6 +203,19 @@
 					<discord-system-message type="missed-call"> You missed a call from <i>Favna</i> that lasted a minute. </discord-system-message>
 					<discord-system-message type="leave"> <i>Favna</i> left the group. </discord-system-message>
 				</discord-messages>
+				<h3 class="title">Threads</h3>
+				<discord-messages>
+					<discord-system-message type="thread">
+						<i style="color: #a155ab">Favna</i> started a thread: <i>Skyra Suggestion Thread</i>. See all <i>threads</i>.
+						<discord-thread slot="thread" cta="2 Messages">
+							<discord-thread-message profile="skyra">Pong!</discord-thread-message>
+						</discord-thread>
+					</discord-system-message>
+					<discord-message profile="favna">
+						Let's make a thread!
+						<discord-thread slot="thread" name="A cool thread!">There are no messages in this thread yet.</discord-thread>
+					</discord-message>
+				</discord-messages>
 				<h3 class="title">Reactions</h3>
 				<discord-messages>
 					<discord-message profile="favna">

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -27,3 +27,7 @@ export const DiscordSystemMessage = /*@__PURE__*/ createReactComponent<JSX.Disco
 	'discord-system-message'
 );
 export const DiscordTenorVideo = /*@__PURE__*/ createReactComponent<JSX.DiscordTenorVideo, HTMLDiscordTenorVideoElement>('discord-tenor-video');
+export const DiscordThread = /*@__PURE__*/ createReactComponent<JSX.DiscordThread, HTMLDiscordThreadElement>('discord-thread');
+export const DiscordThreadMessage = /*@__PURE__*/ createReactComponent<JSX.DiscordThreadMessage, HTMLDiscordThreadMessageElement>(
+	'discord-thread-message'
+);


### PR DESCRIPTION
Adds `<discord-thread>` and `<discord-thread-message>` to be used in `<discord-message>` and `<discord-system-message>`.

![](https://get.snaz.in/8tLXvdX.png)

```html
<discord-messages>
	<discord-system-message type="thread">
		<i style="color: #a155ab">Favna</i> started a thread: <i>Skyra Suggestion Thread</i>. See all <i>threads</i>.
		<discord-thread slot="thread" cta="2 Messages">
			<discord-thread-message profile="skyra">Pong!</discord-thread-message>
		</discord-thread>
	</discord-system-message>
	<discord-message profile="favna">
		Let's make a thread!
		<discord-thread slot="thread" name="A cool thread!">There are no messages in this thread yet.</discord-thread>
	</discord-message>
</discord-messages>
```