### PR TITLE
feat(discord-embed-description): add styles for nested HTML tags

### DIFF
--- a/packages/core/src/components/discord-embed-description/discord-embed-description.css
+++ b/packages/core/src/components/discord-embed-description/discord-embed-description.css
@@ -9,7 +9,7 @@
 }
 
 .discord-embed .discord-embed-description code {
-	background: #202225;
+	background-color: #202225;
 	padding: 2.5px;
 	border-radius: 3px;
 }
@@ -20,17 +20,17 @@
 	border-radius: 4px;
 	white-space: break-spaces;
 }
-  
+
 .discord-embed .discord-embed-description pre {
 	margin: 0;
 	margin-top: 6px;
 }
-  
+
 .discord-embed .discord-embed-description img.emoji {
 	width: 22px;
 	height: 22px;
 }
-  
+
 .discord-embed .discord-embed-description blockquote {
 	position: relative;
 	padding: 0 8px 0 12px;
@@ -38,21 +38,27 @@
 }
 
 .discord-embed .discord-embed-description blockquote::before {
-	content: "";
+	content: '';
 	display: block;
 	position: absolute;
 	left: 0;
 	height: 100%;
 	width: 4px;
 	border-radius: 4px;
-	background: #4f545c;
+	background-color: #4f545c;
 }
 
 .discord-embed .discord-embed-description .spoiler {
-	background: #202225;
+	background-color: #202225;
 	color: transparent;
+	cursor: pointer;
+}
+
+.discord-embed .discord-embed-description .spoiler:hover {
+	background-color: rgba(32, 34, 37, 0.8);
 }
 
 .discord-embed .discord-embed-description .spoiler:active {
 	color: inherit;
+	background-color: hsla(0, 0%, 100%, 0.1);
 }

--- a/packages/core/src/components/discord-embed-description/discord-embed-description.css
+++ b/packages/core/src/components/discord-embed-description/discord-embed-description.css
@@ -7,3 +7,52 @@
 	min-width: 0;
 	white-space: pre-line;
 }
+
+.discord-embed .discord-embed-description code {
+	background: #202225;
+	padding: 2.5px;
+	border-radius: 3px;
+}
+
+.discord-embed .discord-embed-description code.multiline {
+	display: block;
+	padding: 7px;
+	border-radius: 4px;
+	white-space: break-spaces;
+}
+  
+.discord-embed .discord-embed-description pre {
+	margin: 0;
+	margin-top: 6px;
+}
+  
+.discord-embed .discord-embed-description img.emoji {
+	width: 22px;
+	height: 22px;
+}
+  
+.discord-embed .discord-embed-description blockquote {
+	position: relative;
+	padding: 0 8px 0 12px;
+	margin: 0;
+}
+
+.discord-embed .discord-embed-description blockquote::before {
+	content: "";
+	display: block;
+	position: absolute;
+	left: 0;
+	height: 100%;
+	width: 4px;
+	border-radius: 4px;
+	background: #4f545c;
+}
+
+.discord-embed .discord-embed-description .spoiler {
+	background: #202225;
+	color: transparent;
+}
+
+.discord-embed .discord-embed-description .spoiler:active {
+	color: inherit;
+}

--- a/packages/core/src/components/discord-embed-description/discord-embed-description.css
+++ b/packages/core/src/components/discord-embed-description/discord-embed-description.css
@@ -14,6 +14,10 @@
 	border-radius: 3px;
 }
 
+.discord-light-theme .discord-embed-description code {
+	background-color: #e3e5e8;
+}
+
 .discord-embed .discord-embed-description code.multiline {
 	display: block;
 	padding: 7px;
@@ -48,17 +52,33 @@
 	background-color: #4f545c;
 }
 
+.discord-light-theme .discord-embed-description blockquote::before {
+	background-color: #c7ccd1;
+}
+
 .discord-embed .discord-embed-description .spoiler {
 	background-color: #202225;
 	color: transparent;
 	cursor: pointer;
 }
 
+.discord-light-theme .discord-embed .discord-embed-description .spoiler {
+	background-color: #b9bbbe;
+}
+
 .discord-embed .discord-embed-description .spoiler:hover {
 	background-color: rgba(32, 34, 37, 0.8);
+}
+
+.discord-light-theme .discord-embed .discord-embed-description .spoiler:hover {
+	background-color: rgba(185,187,190,.8);
 }
 
 .discord-embed .discord-embed-description .spoiler:active {
 	color: inherit;
 	background-color: hsla(0, 0%, 100%, 0.1);
+}
+
+.discord-light-theme .discord-embed .discord-embed-description .spoiler:active {
+	background-color: rgba(0,0,0,.1);
 }

--- a/packages/core/src/components/discord-embed-description/discord-embed-description.css
+++ b/packages/core/src/components/discord-embed-description/discord-embed-description.css
@@ -71,7 +71,7 @@
 }
 
 .discord-light-theme .discord-embed .discord-embed-description .spoiler:hover {
-	background-color: rgba(185,187,190,.8);
+	background-color: rgba(185, 187, 190, 0.8);
 }
 
 .discord-embed .discord-embed-description .spoiler:active {
@@ -80,5 +80,5 @@
 }
 
 .discord-light-theme .discord-embed .discord-embed-description .spoiler:active {
-	background-color: rgba(0,0,0,.1);
+	background-color: rgba(0, 0, 0, 0.1);
 }

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -396,6 +396,30 @@
 						</discord-embed>
 					</discord-message>
 				</discord-messages>
+				<h3 class="title">Embed description built-in styling example</h3>
+				<discord-messages>
+					<discord-message profile="skyra">
+						<discord-embed slot="embeds" color="#0F52BA">
+							<discord-embed-description slot="description">
+								You can use several HTML tags to get discord-like styling in your embed description:
+								<ul>
+									<li>&lt;code&gt;content&lt;/code&gt; for <code>content</code><br /></li>
+									<li>&lt;code class="multiline"&gt;content&lt;/code&gt; for <code class="multiline">content</code></li>
+									<li>
+										&lt;pre&gt;content&lt;/pre&gt; for
+										<pre>content</pre>
+									</li>
+									<li>&lt;img class="emoji" /&gt; for <img class="emoji" src="/static/sapphire.png" /></li>
+									<li>
+										&lt;blockquote&gt;content&lt;/blockquote&gt; for
+										<blockquote>content</blockquote>
+									</li>
+									<li>&lt;span class="spoiler"&gt;content&lt;/span&gt; for <span class="spoiler">content</span></li>
+								</ul>
+							</discord-embed-description>
+						</discord-embed>
+					</discord-message>
+				</discord-messages>
 				<h3 class="title">Server crosspost messages</h3>
 				<discord-messages>
 					<discord-message profile="discordjs" timestamp="12/06/2021">


### PR DESCRIPTION
Added styles for the html elements that are the basic markdown equivalents of:
inline emoji, inline code, multiline code, blockquote, and spoiler.

Upon closer inspection bold, italic, strikethrough, and underline are all used 'as is' already by discord so no additional styling needed. 
(Originally thought bold was off because it didn't match field titles, but it seems that's just the way discord does things).

Feel free to let me know if the classnames I included are ok or not - I don't have any reason I can't change them. 

I also did a little bit of cleverness around blockquotes to get the line to match discord's but without needing any additional tags, since a plain blockquote tag is all a markdown generator would create. And I did a little bit of extra on spoilers so that you can 'view' the text if you're actively 'mousedown' on the spoiler but without javascript it won't get any closer than that to what discord has.

---

Edit by maintainer:

Closes #193