### PR TITLE
feat: add `discord-time` component

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -449,6 +449,8 @@ export namespace Components {
          */
         "verified": boolean;
     }
+    interface DiscordTime {
+    }
     interface DiscordUnderlined {
     }
 }
@@ -615,6 +617,12 @@ declare global {
         prototype: HTMLDiscordThreadMessageElement;
         new (): HTMLDiscordThreadMessageElement;
     };
+    interface HTMLDiscordTimeElement extends Components.DiscordTime, HTMLStencilElement {
+    }
+    var HTMLDiscordTimeElement: {
+        prototype: HTMLDiscordTimeElement;
+        new (): HTMLDiscordTimeElement;
+    };
     interface HTMLDiscordUnderlinedElement extends Components.DiscordUnderlined, HTMLStencilElement {
     }
     var HTMLDiscordUnderlinedElement: {
@@ -649,6 +657,7 @@ declare global {
         "discord-tenor-video": HTMLDiscordTenorVideoElement;
         "discord-thread": HTMLDiscordThreadElement;
         "discord-thread-message": HTMLDiscordThreadMessageElement;
+        "discord-time": HTMLDiscordTimeElement;
         "discord-underlined": HTMLDiscordUnderlinedElement;
     }
 }
@@ -1095,6 +1104,8 @@ declare namespace LocalJSX {
          */
         "verified"?: boolean;
     }
+    interface DiscordTime {
+    }
     interface DiscordUnderlined {
     }
     interface IntrinsicElements {
@@ -1125,6 +1136,7 @@ declare namespace LocalJSX {
         "discord-tenor-video": DiscordTenorVideo;
         "discord-thread": DiscordThread;
         "discord-thread-message": DiscordThreadMessage;
+        "discord-time": DiscordTime;
         "discord-underlined": DiscordUnderlined;
     }
 }
@@ -1159,6 +1171,7 @@ declare module "@stencil/core" {
             "discord-tenor-video": LocalJSX.DiscordTenorVideo & JSXBase.HTMLAttributes<HTMLDiscordTenorVideoElement>;
             "discord-thread": LocalJSX.DiscordThread & JSXBase.HTMLAttributes<HTMLDiscordThreadElement>;
             "discord-thread-message": LocalJSX.DiscordThreadMessage & JSXBase.HTMLAttributes<HTMLDiscordThreadMessageElement>;
+            "discord-time": LocalJSX.DiscordTime & JSXBase.HTMLAttributes<HTMLDiscordTimeElement>;
             "discord-underlined": LocalJSX.DiscordUnderlined & JSXBase.HTMLAttributes<HTMLDiscordUnderlinedElement>;
         }
     }

--- a/packages/core/src/components/discord-time/discord-time.css
+++ b/packages/core/src/components/discord-time/discord-time.css
@@ -1,0 +1,5 @@
+.discord-time {
+	background-color: #ffffff0f;
+	border-radius: 3px;
+	padding: 0 2px;
+}

--- a/packages/core/src/components/discord-time/discord-time.tsx
+++ b/packages/core/src/components/discord-time/discord-time.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from '@stencil/core';
+import { Component, h, Host } from '@stencil/core';
 
 @Component({
 	tag: 'discord-time',
@@ -7,9 +7,9 @@ import { Component, h } from '@stencil/core';
 export class DiscordTime {
 	public render() {
 		return (
-			<span class="discord-time">
+			<Host class="discord-time">
 				<slot></slot>
-			</span>
+			</Host>
 		);
 	}
 }

--- a/packages/core/src/components/discord-time/discord-time.tsx
+++ b/packages/core/src/components/discord-time/discord-time.tsx
@@ -1,0 +1,15 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+	tag: 'discord-time',
+	styleUrl: 'discord-time.css'
+})
+export class DiscordTime {
+	public render() {
+		return (
+			<span class="discord-time">
+				<slot></slot>
+			</span>
+		);
+	}
+}

--- a/packages/core/src/components/discord-time/readme.md
+++ b/packages/core/src/components/discord-time/readme.md
@@ -1,0 +1,7 @@
+# discord-time
+
+<!-- Auto Generated Below -->
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -380,6 +380,7 @@
 								languages) to inspire Sapphire, it has become the ultimate modern experience of writing your code.
 							</discord-embed-description>
 							<discord-embed-fields slot="fields">
+								<discord-embed-field field-title="Created"><discord-time>1 year ago</discord-time></discord-embed-field>
 								<discord-embed-field field-title="Installation"> yarn add @sapphire/framework </discord-embed-field>
 								<discord-embed-field field-title="Key Features">
 									<ul style="padding-inline-start: 20px; margin-block-start: 0.5em">

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -41,4 +41,5 @@ export const DiscordThread = /*@__PURE__*/ createReactComponent<JSX.DiscordThrea
 export const DiscordThreadMessage = /*@__PURE__*/ createReactComponent<JSX.DiscordThreadMessage, HTMLDiscordThreadMessageElement>(
 	'discord-thread-message'
 );
+export const DiscordTime = /*@__PURE__*/ createReactComponent<JSX.DiscordTime, HTMLDiscordTimeElement>('discord-time');
 export const DiscordUnderlined = /*@__PURE__*/ createReactComponent<JSX.DiscordUnderlined, HTMLDiscordUnderlinedElement>('discord-underlined');


### PR DESCRIPTION
Adds discord timestamp styling (`discord-time`)
![](https://get.snaz.in/28rPvm5.png)