### PR TITLE
feat: add ephemeral messages and highlight fixes

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -250,6 +250,10 @@ export namespace Components {
          */
         "edited": boolean;
         /**
+          * Whether to make this message ephemeral.
+         */
+        "ephemeral": boolean;
+        /**
           * Whether to highlight this message.
          */
         "highlight": boolean;
@@ -895,6 +899,10 @@ declare namespace LocalJSX {
           * Whether the message has been edited or not.
          */
         "edited"?: boolean;
+        /**
+          * Whether to make this message ephemeral.
+         */
+        "ephemeral"?: boolean;
         /**
           * Whether to highlight this message.
          */

--- a/packages/core/src/components/discord-mention/discord-mention.css
+++ b/packages/core/src/components/discord-mention/discord-mention.css
@@ -46,34 +46,3 @@
 	left: 0.125rem;
 	top: 0.125rem;
 }
-
-.discord-message.discord-highlight-mention {
-	background-color: rgba(250, 166, 26, 0.1);
-	border-radius: 0 3px 3px 0;
-	padding-right: 5px;
-	position: relative;
-}
-
-.discord-light-theme .discord-message.discord-highlight-mention {
-	background-color: rgba(250, 166, 26, 0.1);
-}
-
-.discord-message.discord-highlight-mention:hover {
-	background-color: rgba(250, 166, 26, 0.08);
-}
-
-.discord-light-theme .discord-message.discord-highlight-mention:hover {
-	background-color: rgba(250, 166, 26, 0.2);
-}
-
-.discord-message.discord-highlight-mention::before {
-	background-color: rgb(250, 166, 26);
-	content: ' ';
-	position: relative;
-	display: block;
-	top: 0;
-	left: -0.75rem;
-	bottom: 0;
-	pointer-events: none;
-	width: 2px;
-}

--- a/packages/core/src/components/discord-message/discord-message.css
+++ b/packages/core/src/components/discord-message/discord-message.css
@@ -29,16 +29,14 @@
 	flex: 0 0 auto;
 }
 
-.discord-message.discord-message-highlight {
-	background-color: rgba(250, 166, 26, 0.05);
+.discord-message.discord-highlight-mention,
+.discord-message.discord-highlight-ephemeral {
+	padding-right: 5px;
+	position: relative;
 }
 
-.discord-message.discord-message-highlight:hover {
-	background-color: rgba(250, 166, 26, 0.08);
-}
-
-.discord-message.discord-message-highlight::before {
-	background-color: #faa61a;
+.discord-message.discord-highlight-mention::before,
+.discord-message.discord-highlight-ephemeral::before {
 	content: '';
 	position: absolute;
 	display: block;
@@ -47,6 +45,42 @@
 	bottom: 0;
 	pointer-events: none;
 	width: 2px;
+}
+
+.discord-message.discord-highlight-mention {
+	background-color: rgba(250, 166, 26, 0.1);
+}
+
+.discord-light-theme .discord-message.discord-highlight-mention {
+	background-color: rgba(250, 166, 26, 0.1);
+}
+
+.discord-message.discord-highlight-mention:hover {
+	background-color: rgba(250, 166, 26, 0.08);
+}
+
+.discord-light-theme .discord-message.discord-highlight-mention:hover {
+	background-color: rgba(250, 166, 26, 0.2);
+}
+
+.discord-message.discord-highlight-mention::before {
+	background-color: #faa61a;
+}
+
+.discord-message.discord-highlight-ephemeral {
+	background-color: rgba(88, 101, 242, 0.05);
+}
+
+.discord-light-theme .discord-message.discord-highlight-ephemeral {
+	background-color: rgba(250, 166, 26, 0.1);
+}
+
+.discord-message.discord-highlight-ephemeral:hover {
+	background-color: rgba(88, 101, 242, 0.1);
+}
+
+.discord-message.discord-highlight-ephemeral::before {
+	background-color: #5865f2;
 }
 
 .discord-light-theme .discord-message {
@@ -223,6 +257,33 @@
 
 .discord-light-theme .discord-message.discord-message-has-thread:after {
 	border-color: #747f8d;
+}
+
+.discord-message-ephemeral {
+	color: #72767d;
+	margin-top: 4px;
+	font-size: 12px;
+	font-weight: 400;
+	color: #72767d;
+}
+
+.discord-light-theme .discord-message-ephemeral {
+	color: #747f8d;
+}
+
+.discord-message-ephemeral .discord-message-ephemeral-link {
+	color: #00aff4;
+	font-weight: 500;
+	cursor: pointer;
+}
+
+.discord-message-ephemeral .discord-message-ephemeral-link:hover {
+	text-decoration: underline;
+}
+
+.discord-message-ephemeral .discord-message-ephemeral-icon {
+	margin-right: 4px;
+	vertical-align: text-bottom;
 }
 
 @import '../author-info/author-info.css';

--- a/packages/core/src/components/discord-message/discord-message.tsx
+++ b/packages/core/src/components/discord-message/discord-message.tsx
@@ -4,6 +4,7 @@ import Fragment from '../../Fragment';
 import { avatars, Profile, profiles } from '../../options';
 import { DiscordTimestamp, handleTimestamp } from '../../util';
 import { AuthorInfo } from '../author-info/author-info';
+import Ephemeral from '../svgs/ephemeral';
 
 @Component({
 	tag: 'discord-message',
@@ -75,6 +76,12 @@ export class DiscordMessage implements ComponentInterface {
 	public highlight = false;
 
 	/**
+	 * Whether to make this message ephemeral.
+	 */
+	@Prop()
+	public ephemeral = false;
+
+	/**
 	 * The timestamp to use for the message date.
 	 */
 	@Prop({ mutable: true, reflect: true })
@@ -123,7 +130,13 @@ export class DiscordMessage implements ComponentInterface {
 			});
 
 		return (
-			<Host class={clsx('discord-message', { 'discord-highlight-mention': highlightMention, 'discord-message-has-thread': hasThread })}>
+			<Host
+				class={clsx('discord-message', {
+					'discord-highlight-mention': highlightMention,
+					'discord-message-has-thread': hasThread,
+					'discord-highlight-ephemeral': this.ephemeral
+				})}
+			>
 				<slot name="reply"></slot>
 				<div class="discord-message-inner">
 					{parent.compactMode && <span class="discord-message-timestamp">{this.timestamp}</span>}
@@ -166,6 +179,14 @@ export class DiscordMessage implements ComponentInterface {
 							<slot name="components"></slot>
 							<slot name="reactions"></slot>
 							<slot name="thread"></slot>
+							{this.ephemeral ? (
+								<div class="discord-message-ephemeral">
+									<Ephemeral class="discord-message-ephemeral-icon" />
+									Only you can see this • <span class="discord-message-ephemeral-link">Dismiss message</span>
+								</div>
+							) : (
+								''
+							)}
 						</div>
 					</div>
 				</div>

--- a/packages/core/src/components/discord-message/discord-message.tsx
+++ b/packages/core/src/components/discord-message/discord-message.tsx
@@ -179,13 +179,11 @@ export class DiscordMessage implements ComponentInterface {
 							<slot name="components"></slot>
 							<slot name="reactions"></slot>
 							<slot name="thread"></slot>
-							{this.ephemeral ? (
+							{this.ephemeral && (
 								<div class="discord-message-ephemeral">
 									<Ephemeral class="discord-message-ephemeral-icon" />
 									Only you can see this • <span class="discord-message-ephemeral-link">Dismiss message</span>
 								</div>
-							) : (
-								''
 							)}
 						</div>
 					</div>

--- a/packages/core/src/components/discord-message/readme.md
+++ b/packages/core/src/components/discord-message/readme.md
@@ -10,6 +10,7 @@
 | `avatar`     | `avatar`      | The message author's avatar. Can be an avatar shortcut, relative path, or external link.                                      | `string`                 | `undefined`  |
 | `bot`        | `bot`         | Whether the message author is a bot or not. Only works if `server` is `false` or `undefined`.                                 | `boolean`                | `false`      |
 | `edited`     | `edited`      | Whether the message has been edited or not.                                                                                   | `boolean`                | `false`      |
+| `ephemeral`  | `ephemeral`   | Whether to make this message ephemeral.                                                                                       | `boolean`                | `false`      |
 | `highlight`  | `highlight`   | Whether to highlight this message.                                                                                            | `boolean`                | `false`      |
 | `profile`    | `profile`     | The id of the profile data to use.                                                                                            | `string`                 | `undefined`  |
 | `roleColor`  | `role-color`  | The message author's primary role color. Can be any [CSS color value](https://www.w3schools.com/cssref/css_colors_legal.asp). | `string`                 | `undefined`  |

--- a/packages/core/src/components/svgs/ephemeral.tsx
+++ b/packages/core/src/components/svgs/ephemeral.tsx
@@ -1,0 +1,16 @@
+import { h } from '@stencil/core';
+
+export default function Ephemeral<T>(props: T) {
+	return (
+		<svg {...props} aria-hidden="false" width="16" height="16" viewBox="0 0 24 24">
+			<path
+				fill="currentColor"
+				d="M12 5C5.648 5 1 12 1 12C1 12 5.648 19 12 19C18.352 19 23 12 23 12C23 12 18.352 5 12 5ZM12 16C9.791 16 8 14.21 8 12C8 9.79 9.791 8 12 8C14.209 8 16 9.79 16 12C16 14.21 14.209 16 12 16Z"
+			></path>
+			<path
+				fill="currentColor"
+				d="M12 14C13.1046 14 14 13.1046 14 12C14 10.8954 13.1046 10 12 10C10.8954 10 10 10.8954 10 12C10 13.1046 10.8954 14 12 14Z"
+			></path>
+		</svg>
+	);
+}

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -316,7 +316,7 @@
 						<discord-command slot="reply" profile="favna" command="/ping"></discord-command>
 						Pong!
 					</discord-message>
-					<discord-message profile="skyra">
+					<discord-message profile="skyra" ephemeral>
 						<discord-reply slot="reply" profile="skyra" command>Pong!</discord-reply>
 						Took 100ms.
 					</discord-message>
@@ -327,7 +327,7 @@
 						<discord-command slot="reply" profile="favna" command="/ping"></discord-command>
 						Pong!
 					</discord-message>
-					<discord-message profile="skyra">
+					<discord-message profile="skyra" ephemeral>
 						<discord-reply slot="reply" profile="skyra" command>Pong!</discord-reply>
 						Took 100ms.
 					</discord-message>


### PR DESCRIPTION
Added ephemeral message option to `discord-message`.
![](https://get.snaz.in/61e4Y3d.png)

Also pushed highlighting CSS rules `discord-message` rather than `discord-mention` and fixed the highlight border.
![](https://get.snaz.in/5LpkMTL.png)