### PR TITLE
feat: mention for slash commands

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -227,9 +227,9 @@ export namespace Components {
          */
         "highlight": boolean;
         /**
-          * The type of mention this should be. This will prepend the proper prefix character. Valid values: `user`, `channel`, `role`, `voice`, `locked`, `thread`, and `forum`.
+          * The type of mention this should be. This will prepend the proper prefix character. Valid values: `user`, `channel`, `role`, `voice`, `locked`, `thread`, `forum`, and `slash`.
          */
-        "type": 'user' | 'channel' | 'role' | 'voice' | 'locked' | 'thread' | 'forum';
+        "type": 'user' | 'channel' | 'role' | 'voice' | 'locked' | 'thread' | 'forum' | 'slash';
     }
     interface DiscordMessage {
         /**
@@ -902,9 +902,9 @@ declare namespace LocalJSX {
          */
         "highlight"?: boolean;
         /**
-          * The type of mention this should be. This will prepend the proper prefix character. Valid values: `user`, `channel`, `role`, `voice`, `locked`, `thread`, and `forum`.
+          * The type of mention this should be. This will prepend the proper prefix character. Valid values: `user`, `channel`, `role`, `voice`, `locked`, `thread`, `forum`, and `slash`.
          */
-        "type"?: 'user' | 'channel' | 'role' | 'voice' | 'locked' | 'thread' | 'forum';
+        "type"?: 'user' | 'channel' | 'role' | 'voice' | 'locked' | 'thread' | 'forum' | 'slash';
     }
     interface DiscordMessage {
         /**

--- a/packages/core/src/components/discord-mention/discord-mention.tsx
+++ b/packages/core/src/components/discord-mention/discord-mention.tsx
@@ -31,17 +31,19 @@ export class DiscordMention implements ComponentInterface {
 
 	/**
 	 * The type of mention this should be. This will prepend the proper prefix character.
-	 * Valid values: `user`, `channel`, `role`, `voice`, `locked`, `thread`, and `forum`.
+	 * Valid values: `user`, `channel`, `role`, `voice`, `locked`, `thread`, `forum`, and `slash`.
 	 */
 	@Prop()
-	public type: 'user' | 'channel' | 'role' | 'voice' | 'locked' | 'thread' | 'forum' = 'user';
+	public type: 'user' | 'channel' | 'role' | 'voice' | 'locked' | 'thread' | 'forum' | 'slash' = 'user';
 
 	@Watch('type')
 	public handleType(value: string) {
 		if (typeof value !== 'string') {
 			throw new TypeError('DiscordMention `type` prop must be a string.');
-		} else if (!['user', 'channel', 'role', 'voice', 'locked', 'thread', 'forum'].includes(value)) {
-			throw new RangeError("DiscordMention `type` prop must be one of: 'user', 'channel', 'role', 'voice', 'locked', 'thread', 'forum'");
+		} else if (!['user', 'channel', 'role', 'voice', 'locked', 'thread', 'forum', 'slash'].includes(value)) {
+			throw new RangeError(
+				"DiscordMention `type` prop must be one of: 'user', 'channel', 'role', 'voice', 'locked', 'thread', 'forum', 'slash'"
+			);
 		}
 	}
 
@@ -100,6 +102,9 @@ export class DiscordMention implements ComponentInterface {
 				break;
 			case 'forum':
 				mentionPrepend = <ChannnelForum class="discord-mention-icon" />;
+				break;
+			case 'slash':
+				mentionPrepend = '/';
 				break;
 		}
 

--- a/packages/core/src/components/discord-mention/readme.md
+++ b/packages/core/src/components/discord-mention/readme.md
@@ -4,11 +4,11 @@
 
 ## Properties
 
-| Property    | Attribute   | Description                                                                                                                                                           | Type                                                                          | Default     |
-| ----------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------- |
-| `color`     | `color`     | The color to use for this mention. Only works for role mentions and must be in hex format.                                                                            | `string`                                                                      | `undefined` |
-| `highlight` | `highlight` | Whether this entire message block should be highlighted (to emulate the "logged in user" being pinged).                                                               | `boolean`                                                                     | `false`     |
-| `type`      | `type`      | The type of mention this should be. This will prepend the proper prefix character. Valid values: `user`, `channel`, `role`, `voice`, `locked`, `thread`, and `forum`. | `"channel" \| "forum" \| "locked" \| "role" \| "thread" \| "user" \| "voice"` | `'user'`    |
+| Property    | Attribute   | Description                                                                                                                                                                    | Type                                                                                     | Default     |
+| ----------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | ----------- |
+| `color`     | `color`     | The color to use for this mention. Only works for role mentions and must be in hex format.                                                                                     | `string`                                                                                 | `undefined` |
+| `highlight` | `highlight` | Whether this entire message block should be highlighted (to emulate the "logged in user" being pinged).                                                                        | `boolean`                                                                                | `false`     |
+| `type`      | `type`      | The type of mention this should be. This will prepend the proper prefix character. Valid values: `user`, `channel`, `role`, `voice`, `locked`, `thread`, `forum`, and `slash`. | `"channel" \| "forum" \| "locked" \| "role" \| "slash" \| "thread" \| "user" \| "voice"` | `'user'`    |
 
 ---
 

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -174,6 +174,9 @@
 						Hey there
 						<discord-mention highlight>Maximillian Osborn</discord-mention>, thanks! I will!
 					</discord-message>
+					<discord-message profile="maximillian">
+						Also, make sure to run <discord-mention type="slash">profile</discord-mention> to create your server profile!
+					</discord-message>
 				</discord-messages>
 				<h3 class="title">Custom Discord Emojis</h3>
 				<discord-messages>


### PR DESCRIPTION
Display slash commands as mentionable in the component. This resolves #287.

![image](https://user-images.githubusercontent.com/16583889/193497879-2489f8e1-9807-4e63-9338-ca2136503598.png)
