### PR TITLE
feat: add video attachment component

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -113,17 +113,6 @@
 			</div>
 
 			<main id="demo">
-				<h3 class="title">Video attachments</h3>
-				<discord-messages>
-					<discord-message profile="favna">
-						Look at this video!
-						<discord-video-attachment
-							slot="attachments"
-							href="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
-							poster="https://favna.s-ul.eu/On2pqpAq.png"
-						/>
-					</discord-message>
-				</discord-messages>
 				<h3 class="title">A normal conversation</h3>
 				<discord-messages>
 					<discord-message author="Alyx Vargas"> Hey guys, I'm new here! Glad to be able to join you all! </discord-message>
@@ -341,6 +330,17 @@
 							name="01 Baldurs Gate 3 OST - Main Theme Part I"
 							bytes="6.38"
 							bytes-unit="MB"
+						/>
+					</discord-message>
+				</discord-messages>
+				<h3 class="title">Video attachments</h3>
+				<discord-messages>
+					<discord-message profile="favna">
+						Look at this video!
+						<discord-video-attachment
+							slot="attachments"
+							href="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+							poster="https://favna.s-ul.eu/On2pqpAq.png"
 						/>
 					</discord-message>
 				</discord-messages>

--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -113,6 +113,17 @@
 			</div>
 
 			<main id="demo">
+				<h3 class="title">Video attachments</h3>
+				<discord-messages>
+					<discord-message profile="favna">
+						Look at this video!
+						<discord-video-attachment
+							slot="attachments"
+							href="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+							poster="https://favna.s-ul.eu/On2pqpAq.png"
+						/>
+					</discord-message>
+				</discord-messages>
 				<h3 class="title">A normal conversation</h3>
 				<discord-messages>
 					<discord-message author="Alyx Vargas"> Hey guys, I'm new here! Glad to be able to join you all! </discord-message>
@@ -323,7 +334,7 @@
 				<h3 class="title">Audio attachments</h3>
 				<discord-messages>
 					<discord-message profile="favna">
-						testing audio upload
+						Listen to this amazing song from Baldur's Gate 3!
 						<discord-audio-attachment
 							slot="attachments"
 							href="https://favna.s-ul.eu/ZJuz23c7.mp3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,8 @@
 		"./discord-thread-message.js": "./dist/components/discord-thread-message/DiscordThreadMessage.js",
 		"./discord-time.js": "./dist/components/discord-time/DiscordTime.js",
 		"./discord-underlined.js": "./dist/components/discord-underlined/DiscordUnderlined.js",
-		"./discord-unordered-list.js": "./dist/components/discord-unordered-list/DiscordUnorderedList.js"
+		"./discord-unordered-list.js": "./dist/components/discord-unordered-list/DiscordUnorderedList.js",
+		"./discord-video-attachment.js": "./dist/components/discord-video-attachment/DiscordVideoAttachment.js"
 	},
 	"sideEffects": [
 		"./dist/index.js",
@@ -89,7 +90,8 @@
 		"./dist/components/discord-thread-message/DiscordThreadMessage.js",
 		"./dist/components/discord-time/DiscordTime.js",
 		"./dist/components/discord-underlined/DiscordUnderlined.js",
-		"./dist/components/discord-unordered-list/DiscordUnorderedList.js"
+		"./dist/components/discord-unordered-list/DiscordUnorderedList.js",
+		"./dist/components/discord-video-attachment/DiscordVideoAttachment.js"
 	],
 	"homepage": "https://github.com/skyra-project/discord-components/tree/main/packages/core#readme",
 	"scripts": {

--- a/packages/core/src/components/_private/DiscordMediaAttachmentStyles.ts
+++ b/packages/core/src/components/_private/DiscordMediaAttachmentStyles.ts
@@ -1,0 +1,65 @@
+import { css } from 'lit';
+
+export const DiscordMediaAttachmentStyles = css`
+	.discord-media-attachment-non-visual-media-item-container {
+		justify-self: start;
+		align-self: start;
+		margin-top: 8px;
+		max-width: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.discord-media-attachment-mosaic-item-media {
+		border-radius: 2px;
+		display: flex;
+		flex-flow: row nowrap;
+		height: 100%;
+		max-height: inherit;
+		max-width: 100%;
+		position: relative;
+	}
+
+	.discord-media-attachment-controls {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		margin-top: 4px;
+		background-color: hsl(0 calc(1 * 0%) 0% / 0.6);
+		border-radius: 3px;
+	}
+
+	.discord-media-attachment-video-button {
+		margin-right: 8px;
+	}
+
+	.discord-media-attachment-control-icon {
+		display: block;
+		width: 24px;
+		height: 24px;
+		padding: 4px;
+		cursor: pointer;
+		flex: 0 0 auto;
+		opacity: 0.6;
+	}
+
+	.discord-media-attachment-duration-time-wrapper {
+		flex: 0 0 auto;
+		margin: 4px;
+		height: 12px;
+	}
+
+	.discord-media-attachment-duration-time-display {
+		font-weight: 500;
+		display: inline-block;
+		font-family: 'gg mono', 'Source Code Pro', Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter',
+			'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace;
+		font-size: 12px;
+		line-height: 12px;
+		vertical-align: text-top;
+	}
+
+	.discord-media-attachment-duration-time-separator {
+		margin: 0 2px;
+	}
+`;

--- a/packages/core/src/components/_private/DiscordMediaLifecycle.ts
+++ b/packages/core/src/components/_private/DiscordMediaLifecycle.ts
@@ -83,6 +83,15 @@ export class DiscordMediaLifecycle extends LitElement {
 		}
 	};
 
+	protected handleSpaceToPlayPause = (event: KeyboardEvent) => {
+		if (event.code === 'Space') {
+			event.preventDefault();
+			event.stopPropagation();
+
+			this.handleClickPlayPauseIcon();
+		}
+	};
+
 	protected handleClickMuteIcon() {
 		if (this.mediaComponentRef.value) {
 			if (this.isMuted) {
@@ -154,9 +163,9 @@ export class DiscordMediaLifecycle extends LitElement {
 
 	protected handleVolumeControlKeyboard(event: KeyboardEvent) {
 		let volumeChange = 0;
-		if (event.key === 'ArrowDown') {
+		if (event.code === 'ArrowDown') {
 			volumeChange = -0.1;
-		} else if (event.key === 'ArrowUp') {
+		} else if (event.code === 'ArrowUp') {
 			volumeChange = 0.1;
 		}
 
@@ -199,8 +208,6 @@ export class DiscordMediaLifecycle extends LitElement {
 	}
 
 	public override firstUpdated(changedProperties: Map<PropertyKey, unknown>): void {
-		super.firstUpdated(changedProperties);
-
 		if (!this.hasRunUpdate) {
 			if (this.mediaComponentRef.value) {
 				if (this.mediaComponentRef.value.readyState > 0) {
@@ -213,6 +220,7 @@ export class DiscordMediaLifecycle extends LitElement {
 			}
 
 			this.hasRunUpdate = true;
+			super.firstUpdated(changedProperties);
 		}
 	}
 

--- a/packages/core/src/components/_private/DiscordPlaybackControlStyles.ts
+++ b/packages/core/src/components/_private/DiscordPlaybackControlStyles.ts
@@ -1,13 +1,13 @@
 import { css } from 'lit';
 
 export const DiscordPlaybackControlStyles = css`
-	.discord-audio-attachment-horizontal {
+	.discord-media-attachment-horizontal {
 		width: 100%;
 		display: flex;
 		align-self: stretch;
 	}
 
-	.discord-audio-attachment-media-bar-interaction {
+	.discord-media-attachment-media-bar-interaction {
 		position: relative;
 		flex: 1 1 auto;
 		align-self: stretch;
@@ -17,18 +17,18 @@ export const DiscordPlaybackControlStyles = css`
 		margin: 0 7px;
 	}
 
-	.discord-audio-attachment-playback-control {
+	.discord-media-attachment-playback-control {
 		position: relative;
 		flex: 1 1 auto;
 		height: 6px;
 		background-color: hsl(210 calc(1 * 9.3%) 78.8% / 0.3);
 	}
 
-	.discord-audio-attachment-playback-control:hover {
+	.discord-media-attachment-playback-control:hover {
 		box-shadow: 0 1px 1px hsl(0 calc(1 * 0%) 0% / 0.3);
 	}
 
-	.discord-audio-attachment-playback-control::before {
+	.discord-media-attachment-playback-control::before {
 		background-color: hsl(210 calc(1 * 9.3%) 78.8% / 0.3);
 		left: -3px;
 		border-radius: 3px 0 0 3px;
@@ -40,7 +40,7 @@ export const DiscordPlaybackControlStyles = css`
 		z-index: 1;
 	}
 
-	input[type='range'].discord-audio-attachment-playback-control::-webkit-slider-runnable-track {
+	input[type='range'].discord-media-attachment-playback-control::-webkit-slider-runnable-track {
 		width: 2.47264%;
 		height: 100%;
 		cursor: pointer;
@@ -48,7 +48,7 @@ export const DiscordPlaybackControlStyles = css`
 		background: linear-gradient(to right, hsl(199 100% calc(1 * 69%) / 1) var(--buffered-width));
 	}
 
-	input[type='range'].discord-audio-attachment-playback-control::before {
+	input[type='range'].discord-media-attachment-playback-control::before {
 		position: absolute;
 		content: '';
 		top: 0;
@@ -59,7 +59,7 @@ export const DiscordPlaybackControlStyles = css`
 		cursor: pointer;
 	}
 
-	input[type='range'].discord-audio-attachment-playback-control::-webkit-slider-thumb {
+	input[type='range'].discord-media-attachment-playback-control::-webkit-slider-thumb {
 		position: relative;
 		cursor: pointer;
 		border-radius: 3px;
@@ -80,12 +80,12 @@ export const DiscordPlaybackControlStyles = css`
 		z-index: 4;
 	}
 
-	input[type='range'].discord-audio-attachment-playback-control:active::-webkit-slider-thumb {
+	input[type='range'].discord-media-attachment-playback-control:active::-webkit-slider-thumb {
 		transform: scale(1.2);
 		filter: brightness(85%);
 	}
 
-	input[type='range'].discord-audio-attachment-playback-control::-moz-range-track {
+	input[type='range'].discord-media-attachment-playback-control::-moz-range-track {
 		width: 2.47264%;
 		height: 100%;
 		cursor: pointer;
@@ -93,15 +93,15 @@ export const DiscordPlaybackControlStyles = css`
 		background: linear-gradient(to right, hsl(199 100% calc(1 * 69%) / 1) var(--buffered-width));
 	}
 
-	input[type='range'].discord-audio-attachment-playback-control::-moz-range-progress {
+	input[type='range'].discord-media-attachment-playback-control::-moz-range-progress {
 		background-color: hsl(199 100% calc(1 * 69%) / 1);
 	}
 
-	input[type='range'].discord-audio-attachment-playback-control::-moz-focus-outer {
+	input[type='range'].discord-media-attachment-playback-control::-moz-focus-outer {
 		border: 0;
 	}
 
-	input[type='range'].discord-audio-attachment-playback-control::-moz-range-thumb {
+	input[type='range'].discord-media-attachment-playback-control::-moz-range-thumb {
 		border-radius: 50%;
 		position: relative;
 		cursor: pointer;
@@ -118,7 +118,7 @@ export const DiscordPlaybackControlStyles = css`
 		margin: -5px 0 0 0;
 	}
 
-	input[type='range'].discord-audio-attachment-playback-control:active::-moz-range-thumb {
+	input[type='range'].discord-media-attachment-playback-control:active::-moz-range-thumb {
 		transform: scale(1.2);
 		filter: brightness(85%);
 	}

--- a/packages/core/src/components/_private/DiscordVolumeControlStyles.ts
+++ b/packages/core/src/components/_private/DiscordVolumeControlStyles.ts
@@ -13,7 +13,7 @@ export const DiscordVolumeControlStyles = css`
 		position: relative;
 	}
 
-	.discord-media-attachment-volume-button-slider {
+	.discord-media-attachment-button-slider {
 		margin-bottom: 4px;
 		margin-left: -4px;
 		position: absolute;
@@ -34,7 +34,7 @@ export const DiscordVolumeControlStyles = css`
 		width: 140px;
 	}
 
-	.discord-media-attachment-volume-button {
+	.discord-media-attachment-button {
 		cursor: pointer;
 		line-height: 0;
 		width: auto;
@@ -56,7 +56,7 @@ export const DiscordVolumeControlStyles = css`
 		user-select: none;
 	}
 
-	.discord-media-attachment-volume-button-content {
+	.discord-media-attachment-button-content {
 		--custom-button-link-underline-offset: 1px;
 		--button--underline-color: transparent;
 		--custom-button-link-underline-width: 1px;
@@ -72,7 +72,7 @@ export const DiscordVolumeControlStyles = css`
 		);
 	}
 
-	.discord-media-attachment-volume-button-control-icon {
+	.discord-media-attachment-button-control-icon {
 		display: block;
 		width: 24px;
 		height: 24px;

--- a/packages/core/src/components/_private/DiscordVolumeControlStyles.ts
+++ b/packages/core/src/components/_private/DiscordVolumeControlStyles.ts
@@ -1,11 +1,11 @@
 import { css } from 'lit';
 
 export const DiscordVolumeControlStyles = css`
-	.discord-audio-attachment-flex {
+	.discord-media-attachment-flex {
 		display: flex;
 	}
 
-	.discord-audio-attachment-flex-container {
+	.discord-media-attachment-flex-container {
 		justify-content: flex-end;
 		align-items: center;
 		flex-direction: column;
@@ -13,7 +13,7 @@ export const DiscordVolumeControlStyles = css`
 		position: relative;
 	}
 
-	.discord-audio-attachment-volume-button-slider {
+	.discord-media-attachment-volume-button-slider {
 		margin-bottom: 4px;
 		margin-left: -4px;
 		position: absolute;
@@ -25,7 +25,7 @@ export const DiscordVolumeControlStyles = css`
 		-webkit-app-region: no-drag;
 	}
 
-	.discord-audio-attachment-volume-vertical {
+	.discord-media-attachment-volume-vertical {
 		display: flex;
 		align-items: center;
 		transform-origin: top;
@@ -34,7 +34,7 @@ export const DiscordVolumeControlStyles = css`
 		width: 140px;
 	}
 
-	.discord-audio-attachment-volume-button {
+	.discord-media-attachment-volume-button {
 		cursor: pointer;
 		line-height: 0;
 		width: auto;
@@ -56,7 +56,7 @@ export const DiscordVolumeControlStyles = css`
 		user-select: none;
 	}
 
-	.discord-audio-attachment-volume-button-content {
+	.discord-media-attachment-volume-button-content {
 		--custom-button-link-underline-offset: 1px;
 		--button--underline-color: transparent;
 		--custom-button-link-underline-width: 1px;
@@ -72,7 +72,7 @@ export const DiscordVolumeControlStyles = css`
 		);
 	}
 
-	.discord-audio-attachment-volume-button-control-icon {
+	.discord-media-attachment-volume-button-control-icon {
 		display: block;
 		width: 24px;
 		height: 24px;
@@ -82,18 +82,18 @@ export const DiscordVolumeControlStyles = css`
 		opacity: 0.6;
 	}
 
-	.discord-audio-attachment-volume-slider {
+	.discord-media-attachment-volume-slider {
 		position: relative;
 		height: 6px;
 		background-color: hsl(210 calc(1 * 9.3%) 78.8% / 0.3);
 		width: 88px;
 	}
 
-	.discord-audio-attachment-volume-slider:hover {
+	.discord-media-attachment-volume-slider:hover {
 		box-shadow: 0 1px 1px hsl(0 calc(1 * 0%) 0% / 0.3);
 	}
 
-	.discord-audio-attachment-volume-slider::before {
+	.discord-media-attachment-volume-slider::before {
 		background-color: hsl(210 calc(1 * 9.3%) 78.8%/0.3);
 		left: 0px;
 		border-radius: 3px 0 0 3px;
@@ -105,7 +105,7 @@ export const DiscordVolumeControlStyles = css`
 		z-index: 3;
 	}
 
-	input[type='range'].discord-audio-attachment-volume-slider::-webkit-slider-runnable-track {
+	input[type='range'].discord-media-attachment-volume-slider::-webkit-slider-runnable-track {
 		background-color: hsl(210 calc(1 * 9.3%) 78.8%/0.3);
 		height: 2.47264%;
 		width: 100%;
@@ -113,13 +113,13 @@ export const DiscordVolumeControlStyles = css`
 		border-radius: 8px;
 	}
 
-	input[type='range'].discord-audio-attachment-volume-slider::-webkit-slider-thumb {
+	input[type='range'].discord-media-attachment-volume-slider::-webkit-slider-thumb {
 		position: relative;
 		bottom: 8px;
 		z-index: 4;
 	}
 
-	input[type='range'].discord-audio-attachment-volume-slider:active::-webkit-slider-thumb {
+	input[type='range'].discord-media-attachment-volume-slider:active::-webkit-slider-thumb {
 		transform: scale(1.2);
 		filter: brightness(85%);
 	}

--- a/packages/core/src/components/discord-audio-attachment/DiscordAudioAttachment.ts
+++ b/packages/core/src/components/discord-audio-attachment/DiscordAudioAttachment.ts
@@ -204,15 +204,14 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 							<source src=${ifDefined(this.href)} />
 						</audio>
 						<div class="discord-media-attachment-controls" style="transform: translateY(0%)">
-							${/* eslint-disable lit-a11y/click-events-have-key-events */ html``}
 							<div
 								class="discord-media-attachment-video-button"
 								tabindex="0"
 								aria-label="${this.isPlaying ? 'Pause' : 'Play'}"
 								role="button"
 								@click=${this.handleClickPlayPauseIcon}
+								@keydown=${this.handleSpaceToPlayPause}
 							>
-								${/* eslint-enable lit-a11y/click-events-have-key-events */ html``}
 								${when(
 									this.isPlaying,
 									() => AudioVideoPauseIcon({ class: 'discord-media-attachment-control-icon' }),

--- a/packages/core/src/components/discord-audio-attachment/DiscordAudioAttachment.ts
+++ b/packages/core/src/components/discord-audio-attachment/DiscordAudioAttachment.ts
@@ -239,7 +239,7 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 							</div>
 							<div class="discord-media-attachment-flex">
 								<div class="discord-media-attachment-flex-container">
-									<div ${ref(this.volumeControlRef)} class="discord-media-attachment-volume-button-slider">
+									<div ${ref(this.volumeControlRef)} class="discord-media-attachment-button-slider">
 										<div
 											class="discord-media-attachment-volume-vertical"
 											@mouseenter=${this.handleVolumeVerticalEnter}
@@ -258,28 +258,27 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 									<button
 										aria-label="Control volume"
 										type="button"
-										class="discord-media-attachment-volume-button"
+										class="discord-media-attachment-button"
 										@focus=${this.handleVolumeVerticalFocus}
 										@blur=${this.handleVolumeVerticalBlur}
 										@mouseover=${this.handleVolumeVerticalEnter}
 										@mouseout=${this.handleVolumeVerticalLeave}
+										@click=${this.handleClickMuteIcon}
 									>
-										${/* eslint-disable lit-a11y/click-events-have-key-events */ html``}
-										<div class="discord-media-attachment-volume-button-content" @click=${this.handleClickMuteIcon}>
-											${/* eslint-enable lit-a11y/click-events-have-key-events */ html``}
+										<div class="discord-media-attachment-button-content">
 											${when(
 												this.currentVolume === 0 || this.isMuted,
-												() => AudioVideoVolumeMutedIcon({ class: 'discord-media-attachment-volume-button-control-icon' }),
+												() => AudioVideoVolumeMutedIcon({ class: 'discord-media-attachment-button-control-icon' }),
 												() =>
 													when(
 														this.currentVolume <= 0.5,
 														() =>
 															AudioVideoVolumeBelow50PercentIcon({
-																class: 'discord-media-attachment-volume-button-control-icon'
+																class: 'discord-media-attachment-button-control-icon'
 															}),
 														() =>
 															AudioVideoVolumeAbove50PercentIcon({
-																class: 'discord-media-attachment-volume-button-control-icon'
+																class: 'discord-media-attachment-button-control-icon'
 															})
 													)
 											)}

--- a/packages/core/src/components/discord-audio-attachment/DiscordAudioAttachment.ts
+++ b/packages/core/src/components/discord-audio-attachment/DiscordAudioAttachment.ts
@@ -3,8 +3,9 @@ import { css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { createRef, ref } from 'lit/directives/ref.js';
+import { ref } from 'lit/directives/ref.js';
 import { when } from 'lit/directives/when.js';
+import { DiscordMediaAttachmentStyles } from '../_private/DiscordMediaAttachmentStyles.js';
 import { DiscordMediaLifecycle } from '../_private/DiscordMediaLifecycle.js';
 import { DiscordPlaybackControlStyles } from '../_private/DiscordPlaybackControlStyles.js';
 import { DiscordVolumeControlStyles } from '../_private/DiscordVolumeControlStyles.js';
@@ -22,6 +23,7 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 	public static override readonly styles = [
 		DiscordVolumeControlStyles,
 		DiscordPlaybackControlStyles,
+		DiscordMediaAttachmentStyles,
 		css`
 			:host {
 				display: grid;
@@ -42,31 +44,14 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 				--volume-slider-opacity: 0;
 			}
 
-			.discord-audio-attachment-non-visual-media-item-container {
-				justify-self: start;
-				align-self: start;
-				margin-top: 8px;
-				max-width: 100%;
-				display: flex;
-				flex-direction: column;
-			}
-
 			.discord-audio-attachment-non-visual-media-item {
 				width: -moz-fit-content;
 				width: fit-content;
 				max-width: 100%;
 			}
 
-			.discord-audio-attachment-mosaic-item-media {
-				position: relative;
-				max-height: inherit;
-				border-radius: 2px;
+			.discord-media-attachment-mosaic-item-media {
 				width: 100%;
-				align-items: center;
-				display: flex;
-				flex-flow: row nowrap;
-				max-width: 100%;
-				height: 100%;
 			}
 
 			.discord-audio-attachment-wrapper-audio {
@@ -132,53 +117,9 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 				width: 0;
 				height: 0;
 			}
-
-			.discord-audio-attachment-controls {
-				width: 100%;
-				display: flex;
-				align-items: center;
-				margin-top: 4px;
-				background-color: hsl(0 calc(1 * 0%) 0% / 0.6);
-				border-radius: 3px;
-			}
-
-			.discord-audio-attachment-video-button {
-				margin-right: 8px;
-			}
-
-			.discord-audio-attachment-control-icon {
-				display: block;
-				width: 24px;
-				height: 24px;
-				padding: 4px;
-				cursor: pointer;
-				flex: 0 0 auto;
-				opacity: 0.6;
-			}
-
-			.discord-audio-attachment-duration-time-wrapper {
-				flex: 0 0 auto;
-				margin: 4px;
-				height: 12px;
-			}
-
-			.discord-audio-attachment-duration-time-display {
-				font-weight: 500;
-				display: inline-block;
-				font-family: 'gg mono', 'Source Code Pro', Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter',
-					'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace;
-				font-size: 12px;
-				line-height: 12px;
-				vertical-align: text-top;
-			}
-
-			.discord-audio-attachment-duration-time-separator {
-				margin: 0 2px;
-			}
 		`
 	];
 
-	// #region properties
 	/**
 	 * The URL to audio file
 	 * @example
@@ -224,41 +165,13 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 	@consume({ context: messagesLightTheme, subscribe: true })
 	@property({ type: Boolean, reflect: true, attribute: 'light-theme' })
 	public accessor lightTheme = false;
-	// #endregion
-
-	// #region lifecycle
-
-	public override connectedCallback(): void {
-		super.connectedCallback();
-
-		if (this.mediaComponentRef.value) {
-			if (this.mediaComponentRef.value.readyState > 0) {
-				this.displayAudioDuration();
-				this.setSliderMax();
-				this.displayBufferedAmount();
-			} else {
-				this.mediaComponentRef.value.addEventListener('loadedmetadata', this.audioMetadataLoaded);
-			}
-		}
-	}
-
-	public override disconnectedCallback(): void {
-		super.disconnectedCallback();
-
-		this.mediaComponentRef.value?.removeEventListener('loadedmetadata', this.audioMetadataLoaded);
-	}
-	// #endregion
-
-	public constructor() {
-		super(createRef(), createRef(), createRef(), createRef(), '', '0:00', null, false, false, 1);
-	}
 
 	protected override render() {
 		const parsedName = this.name.replace(/\s/g, '_').replace(/[^a-zA-Z0-9_-]/g, '');
 
-		return html`<div class="discord-audio-attachment-non-visual-media-item-container">
+		return html`<div class="discord-media-attachment-non-visual-media-item-container">
 			<div class="discord-audio-attachment-non-visual-media-item">
-				<div class="discord-audio-attachment-mosaic-item-media">
+				<div class="discord-media-attachment-mosaic-item-media">
 					<div
 						class=${classMap({ 'discord-audio-attachment-wrapper-audio': true, 'discord-audio-attachment-light-theme': this.lightTheme })}
 					>
@@ -290,10 +203,10 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 						>
 							<source src=${ifDefined(this.href)} />
 						</audio>
-						<div class="discord-audio-attachment-controls" style="transform: translateY(0%)">
+						<div class="discord-media-attachment-controls" style="transform: translateY(0%)">
 							${/* eslint-disable lit-a11y/click-events-have-key-events */ html``}
 							<div
-								class="discord-audio-attachment-video-button"
+								class="discord-media-attachment-video-button"
 								tabindex="0"
 								aria-label="${this.isPlaying ? 'Pause' : 'Play'}"
 								role="button"
@@ -302,21 +215,21 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 								${/* eslint-enable lit-a11y/click-events-have-key-events */ html``}
 								${when(
 									this.isPlaying,
-									() => AudioVideoPauseIcon({ class: 'discord-audio-attachment-control-icon' }),
-									() => AudioVideoPlayIcon({ class: 'discord-audio-attachment-control-icon' })
+									() => AudioVideoPauseIcon({ class: 'discord-media-attachment-control-icon' }),
+									() => AudioVideoPlayIcon({ class: 'discord-media-attachment-control-icon' })
 								)}
 							</div>
-							<div class="discord-audio-attachment-duration-time-wrapper">
-								<span class="discord-audio-attachment-duration-time-display">${this.currentPlaybackPosition}</span>
-								<span class="discord-audio-attachment-duration-time-display discord-audio-attachment-duration-time-separator">/</span>
-								<span class="discord-audio-attachment-duration-time-display">${this.totalAudioDuration}</span>
+							<div class="discord-media-attachment-duration-time-wrapper">
+								<span class="discord-media-attachment-duration-time-display">${this.currentPlaybackPosition}</span>
+								<span class="discord-media-attachment-duration-time-display discord-media-attachment-duration-time-separator">/</span>
+								<span class="discord-media-attachment-duration-time-display">${this.totalMediaDuration}</span>
 							</div>
-							<div class="discord-audio-attachment-horizontal">
-								<div class="discord-audio-attachment-media-bar-interaction">
+							<div class="discord-media-attachment-horizontal">
+								<div class="discord-media-attachment-media-bar-interaction">
 									<input
 										type="range"
 										${ref(this.seekSliderRef)}
-										class="discord-audio-attachment-playback-control"
+										class="discord-media-attachment-playback-control"
 										@input=${this.handleSeekSliderInput}
 										@change=${this.handleSeekSliderChange}
 										max="100"
@@ -324,18 +237,18 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 									/>
 								</div>
 							</div>
-							<div class="discord-audio-attachment-flex">
-								<div class="discord-audio-attachment-flex-container">
-									<div ${ref(this.volumeControlRef)} class="discord-audio-attachment-volume-button-slider">
+							<div class="discord-media-attachment-flex">
+								<div class="discord-media-attachment-flex-container">
+									<div ${ref(this.volumeControlRef)} class="discord-media-attachment-volume-button-slider">
 										<div
-											class="discord-audio-attachment-volume-vertical"
+											class="discord-media-attachment-volume-vertical"
 											@mouseenter=${this.handleVolumeVerticalEnter}
 											@mouseleave=${this.handleVolumeVerticalLeave}
 										>
 											<input
 												${ref(this.volumeControlInputRef)}
 												type="range"
-												class="discord-audio-attachment-volume-slider"
+												class="discord-media-attachment-volume-slider"
 												@input=${this.handleVolumeSliderInput}
 												max="100"
 												value="100"
@@ -345,28 +258,28 @@ export class DiscordAudioAttachment extends DiscordMediaLifecycle implements Lig
 									<button
 										aria-label="Control volume"
 										type="button"
-										class="discord-audio-attachment-volume-button"
+										class="discord-media-attachment-volume-button"
 										@focus=${this.handleVolumeVerticalFocus}
 										@blur=${this.handleVolumeVerticalBlur}
 										@mouseover=${this.handleVolumeVerticalEnter}
 										@mouseout=${this.handleVolumeVerticalLeave}
 									>
 										${/* eslint-disable lit-a11y/click-events-have-key-events */ html``}
-										<div class="discord-audio-attachment-volume-button-content" @click=${this.handleClickMuteIcon}>
+										<div class="discord-media-attachment-volume-button-content" @click=${this.handleClickMuteIcon}>
 											${/* eslint-enable lit-a11y/click-events-have-key-events */ html``}
 											${when(
 												this.currentVolume === 0 || this.isMuted,
-												() => AudioVideoVolumeMutedIcon({ class: 'discord-audio-attachment-volume-button-control-icon' }),
+												() => AudioVideoVolumeMutedIcon({ class: 'discord-media-attachment-volume-button-control-icon' }),
 												() =>
 													when(
 														this.currentVolume <= 0.5,
 														() =>
 															AudioVideoVolumeBelow50PercentIcon({
-																class: 'discord-audio-attachment-volume-button-control-icon'
+																class: 'discord-media-attachment-volume-button-control-icon'
 															}),
 														() =>
 															AudioVideoVolumeAbove50PercentIcon({
-																class: 'discord-audio-attachment-volume-button-control-icon'
+																class: 'discord-media-attachment-volume-button-control-icon'
 															})
 													)
 											)}

--- a/packages/core/src/components/discord-video-attachment/DiscordVideoAttachment.ts
+++ b/packages/core/src/components/discord-video-attachment/DiscordVideoAttachment.ts
@@ -16,6 +16,7 @@ import AudioVideoPlayIcon from '../svgs/AudioVideoPlayIcon.js';
 import AudioVideoVolumeAbove50PercentIcon from '../svgs/AudioVideoVolumeAbove50PercentIcon.js';
 import AudioVideoVolumeBelow50PercentIcon from '../svgs/AudioVideoVolumeBelow50PercentIcon.js';
 import AudioVideoVolumeMutedIcon from '../svgs/AudioVideoVolumeMutedIcon.js';
+import VideoFullScreenIcon from '../svgs/VideoFullScreenIcon.js';
 import VideoPlayPausePopIcon from '../svgs/VideoPlayPausePopIcon.js';
 import type { LightTheme } from '../../types.js';
 
@@ -185,24 +186,6 @@ export class DiscordVideoAttachment extends DiscordMediaLifecycle implements Lig
 				user-select: none;
 			}
 
-			.discord-video-attachment-full-screen-button-content {
-				--custom-button-link-underline-offset: 1px;
-				--button--underline-color: transparent;
-				--custom-button-link-underline-width: 1px;
-				--custom-button-link-underline-stop: calc(var(--custom-button-link-underline-width) + var(--custom-button-link-underline-offset));
-
-				background-image: linear-gradient(
-					to top,
-					transparent,
-					transparent var(--custom-button-link-underline-offset),
-					var(--button--underline-color) var(--custom-button-link-underline-offset),
-					var(--button--underline-color) var(--custom-button-link-underline-stop),
-					transparent var(--custom-button-link-underline-stop)
-				);
-
-				line-height: 0px;
-			}
-
 			.discord-video-attachment-play-pause-pop {
 				opacity: 0;
 				transform: scale(2.5) translateZ(0px);
@@ -268,6 +251,12 @@ export class DiscordVideoAttachment extends DiscordMediaLifecycle implements Lig
 	@property({ type: Boolean, reflect: true, attribute: 'light-theme' })
 	public accessor lightTheme = false;
 
+	private async handleFullScreenClicked() {
+		if (this.mediaComponentRef.value) {
+			await this.mediaComponentRef.value.requestFullscreen();
+		}
+	}
+
 	protected override render() {
 		return html`<div class="discord-media-attachment-non-visual-media-item-container">
 			<div class="discord-video-attachment-one-by-one-grid">
@@ -332,7 +321,7 @@ export class DiscordVideoAttachment extends DiscordMediaLifecycle implements Lig
 										</div>
 										<div class="discord-media-attachment-flex">
 											<div class="discord-media-attachment-flex-container">
-												<div ${ref(this.volumeControlRef)} class="discord-media-attachment-volume-button-slider">
+												<div ${ref(this.volumeControlRef)} class="discord-media-attachment-button-slider">
 													<div
 														class="discord-media-attachment-volume-vertical"
 														@mouseenter=${this.handleVolumeVerticalEnter}
@@ -351,37 +340,48 @@ export class DiscordVideoAttachment extends DiscordMediaLifecycle implements Lig
 												<button
 													aria-label="Control volume"
 													type="button"
-													class="discord-media-attachment-volume-button"
+													class="discord-media-attachment-button"
 													@focus=${this.handleVolumeVerticalFocus}
 													@blur=${this.handleVolumeVerticalBlur}
 													@mouseover=${this.handleVolumeVerticalEnter}
 													@mouseout=${this.handleVolumeVerticalLeave}
+													@click=${this.handleClickMuteIcon}
 												>
-													${/* eslint-disable lit-a11y/click-events-have-key-events */ html``}
-													<div class="discord-media-attachment-volume-button-content" @click=${this.handleClickMuteIcon}>
-														${/* eslint-enable lit-a11y/click-events-have-key-events */ html``}
+													<div class="discord-media-attachment-button-content">
 														${when(
 															this.currentVolume === 0 || this.isMuted,
 															() =>
 																AudioVideoVolumeMutedIcon({
-																	class: 'discord-media-attachment-volume-button-control-icon'
+																	class: 'discord-media-attachment-button-control-icon'
 																}),
 															() =>
 																when(
 																	this.currentVolume <= 0.5,
 																	() =>
 																		AudioVideoVolumeBelow50PercentIcon({
-																			class: 'discord-media-attachment-volume-button-control-icon'
+																			class: 'discord-media-attachment-button-control-icon'
 																		}),
 																	() =>
 																		AudioVideoVolumeAbove50PercentIcon({
-																			class: 'discord-media-attachment-volume-button-control-icon'
+																			class: 'discord-media-attachment-button-control-icon'
 																		})
 																)
 														)}
 													</div>
 												</button>
 											</div>
+										</div>
+										<div>
+											<button
+												aria-label="Full screen"
+												type="button"
+												class="discord-media-attachment-button"
+												@click=${this.handleFullScreenClicked}
+											>
+												<div class="discord-media-attachment-button-content">
+													${VideoFullScreenIcon({ class: 'discord-media-attachment-button-control-icon' })}
+												</div>
+											</button>
 										</div>
 									</div>
 								</div>

--- a/packages/core/src/components/discord-video-attachment/DiscordVideoAttachment.ts
+++ b/packages/core/src/components/discord-video-attachment/DiscordVideoAttachment.ts
@@ -1,0 +1,404 @@
+import { consume } from '@lit/context';
+import { css, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { ref } from 'lit/directives/ref.js';
+import { when } from 'lit/directives/when.js';
+import { DiscordMediaAttachmentStyles } from '../_private/DiscordMediaAttachmentStyles.js';
+import { DiscordMediaLifecycle } from '../_private/DiscordMediaLifecycle.js';
+import { DiscordPlaybackControlStyles } from '../_private/DiscordPlaybackControlStyles.js';
+import { DiscordVolumeControlStyles } from '../_private/DiscordVolumeControlStyles.js';
+import '../discord-link/DiscordLink.js';
+import { messagesLightTheme } from '../discord-messages/DiscordMessages.js';
+import AudioVideoPauseIcon from '../svgs/AudioVideoPauseIcon.js';
+import AudioVideoPlayIcon from '../svgs/AudioVideoPlayIcon.js';
+import AudioVideoVolumeAbove50PercentIcon from '../svgs/AudioVideoVolumeAbove50PercentIcon.js';
+import AudioVideoVolumeBelow50PercentIcon from '../svgs/AudioVideoVolumeBelow50PercentIcon.js';
+import AudioVideoVolumeMutedIcon from '../svgs/AudioVideoVolumeMutedIcon.js';
+import VideoPlayPausePopIcon from '../svgs/VideoPlayPausePopIcon.js';
+import type { LightTheme } from '../../types.js';
+
+@customElement('discord-video-attachment')
+export class DiscordVideoAttachment extends DiscordMediaLifecycle implements LightTheme {
+	public static override readonly styles = [
+		DiscordVolumeControlStyles,
+		DiscordPlaybackControlStyles,
+		DiscordMediaAttachmentStyles,
+		css`
+			:host {
+				display: grid;
+				height: -moz-fit-content;
+				height: fit-content;
+				grid-auto-flow: row;
+				grid-row-gap: 0.25rem;
+				grid-template-columns: repeat(auto-fill, minmax(100%, 1fr));
+				text-indent: 0;
+				min-height: 0;
+				min-width: 0;
+				padding-top: 0.125rem;
+				padding-bottom: 0.125rem;
+				position: relative;
+
+				--seek-before-width: 0%;
+				--buffered-width: 0%;
+				--volume-slider-opacity: 0;
+			}
+
+			.discord-video-attachment-one-by-one-grid {
+				max-width: 100%;
+				border-radius: 8px;
+				overflow: hidden;
+				display: inline-block;
+				width: -moz-fit-content;
+				width: fit-content;
+				max-height: 350px;
+			}
+
+			.discord-media-attachment-mosaic-item-media {
+				overflow: hidden;
+				align-items: start;
+				justify-self: auto !important;
+			}
+
+			.discord-video-attachment-image-wrapper {
+				display: block;
+				max-height: inherit;
+				margin: auto;
+				width: 550px;
+				height: 100%;
+				flex: auto;
+				position: relative;
+				-webkit-user-select: text;
+				-moz-user-select: text;
+				user-select: text;
+				overflow: hidden;
+				border-radius: 3px;
+			}
+
+			.discord-video-attachment-loading-overlay {
+				aspect-ratio: 1.74603 / 1;
+				width: 100%;
+				height: 100%;
+			}
+
+			.discord-video-attachment-wrapper {
+				height: 100%;
+				width: 100%;
+				max-height: inherit;
+				position: relative;
+				overflow: hidden;
+				border-radius: 3px;
+				color: hsl(0 calc(1 * 0%) 100% / 1);
+				-webkit-user-select: none;
+				-moz-user-select: none;
+				user-select: none;
+				background-color: hsl(225 calc(1 * 6.3%) 12.5% / 1);
+			}
+
+			.discord-video-attachment-wrapper-light-theme.discord-video-attachment-wrapper {
+				background-color: hsl(0 calc(1 * 0%) 97.6% / 1);
+			}
+
+			.discord-video-attachment-video-container {
+				width: 100%;
+				height: 100%;
+				max-height: inherit;
+				object-fit: cover;
+				position: relative;
+				display: block;
+				-o-object-fit: cover;
+				border-radius: 3px;
+			}
+
+			.discord-video-attachment-video-container::-webkit-media-controls-enclosure {
+				display: none !important;
+			}
+
+			.discord-video-attachment-video-controls {
+				position: absolute;
+				left: 0;
+				right: 0;
+				bottom: -10px;
+				padding-bottom: 10px;
+				width: 100%;
+				display: flex;
+				align-items: center;
+				background-color: hsl(0 calc(1 * 0%) 0% / 0.6);
+				height: 32px;
+			}
+
+			.discord-video-attachment-video-button {
+				margin-right: 8px;
+			}
+
+			.discord-video-attachment-control-icon {
+				display: block;
+				width: 24px;
+				height: 24px;
+				padding: 4px;
+				cursor: pointer;
+				flex: 0 0 auto;
+				opacity: 0.6;
+			}
+
+			.discord-video-attachment-duration-time-wrapper {
+				flex: 0 0 auto;
+				margin: 4px;
+				height: 12px;
+			}
+
+			.discord-video-attachment-duration-time-display {
+				font-weight: 500;
+				display: inline-block;
+				font-family: 'gg mono', 'Source Code Pro', Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter',
+					'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace;
+				font-size: 12px;
+				line-height: 12px;
+				vertical-align: text-top;
+			}
+
+			.discord-video-attachment-duration-time-separator {
+				margin: 0 2px;
+			}
+
+			.discord-video-attachment-full-screen-button {
+				cursor: pointer;
+				margin-right: 8px;
+				width: auto;
+				background: transparent;
+				color: currentColor;
+				border: 0;
+				padding: 0;
+				margin: 0;
+				position: relative;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				box-sizing: border-box;
+				border-radius: 3px;
+				font-size: 14px;
+				font-weight: 500;
+				line-height: 16px;
+				-webkit-user-select: none;
+				-moz-user-select: none;
+				user-select: none;
+			}
+
+			.discord-video-attachment-full-screen-button-content {
+				--custom-button-link-underline-offset: 1px;
+				--button--underline-color: transparent;
+				--custom-button-link-underline-width: 1px;
+				--custom-button-link-underline-stop: calc(var(--custom-button-link-underline-width) + var(--custom-button-link-underline-offset));
+
+				background-image: linear-gradient(
+					to top,
+					transparent,
+					transparent var(--custom-button-link-underline-offset),
+					var(--button--underline-color) var(--custom-button-link-underline-offset),
+					var(--button--underline-color) var(--custom-button-link-underline-stop),
+					transparent var(--custom-button-link-underline-stop)
+				);
+
+				line-height: 0px;
+			}
+
+			.discord-video-attachment-play-pause-pop {
+				opacity: 0;
+				transform: scale(2.5) translateZ(0px);
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				margin-left: -23px;
+				margin-top: -23px;
+				padding: 12px;
+				width: 24px;
+				height: 24px;
+				background-color: hsl(0 calc(1 * 0%) 0% / 0.6);
+				color: hsl(0 calc(1 * 0%) 100% / 1);
+				border-radius: 50%;
+				pointer-events: none;
+			}
+
+			.discord-video-attachment-play-pause-pop-icon {
+				width: 24px;
+				height: 24px;
+				display: block;
+			}
+
+			.discord-video-attachment-horizontal {
+				width: 100%;
+				display: flex;
+				align-self: stretch;
+			}
+
+			.discord-video-attachment-media-bar-interaction {
+				position: relative;
+				flex: 1 1 auto;
+				align-self: stretch;
+				display: flex;
+				align-items: center;
+				cursor: pointer;
+				margin: 0 7px;
+			}
+		`
+	];
+
+	/**
+	 * The URL to vidoe file
+	 * @example
+	 * ```ts
+	 * 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm'
+	 * ```
+	 */
+	@property()
+	public accessor href: string;
+
+	/**
+	 * A poster of the video, this is a static image of the video that is used as thumbnail when not yet having played the video
+	 * @example
+	 * ```ts
+	 * 'https://favna.s-ul.eu/On2pqpAq.png'
+	 * ```
+	 */
+	@property()
+	public accessor poster: string;
+
+	@consume({ context: messagesLightTheme, subscribe: true })
+	@property({ type: Boolean, reflect: true, attribute: 'light-theme' })
+	public accessor lightTheme = false;
+
+	protected override render() {
+		return html`<div class="discord-media-attachment-non-visual-media-item-container">
+			<div class="discord-video-attachment-one-by-one-grid">
+				<div class="discord-media-attachment-mosaic-item-media">
+					<div class="discord-video-attachment-image-wrapper">
+						<div class="discord-video-attachment-loading-overlay">
+							<div
+								class=${classMap({
+									'discord-video-attachment-wrapper': true,
+									'discord-video-attachment-wrapper-light-theme': this.lightTheme
+								})}
+							>
+								<video
+									${ref(this.mediaComponentRef)}
+									class="discord-video-attachment-video-container"
+									playsinline
+									height="315"
+									preload="metadata"
+									width="550"
+									poster=${ifDefined(this.poster)}
+									@progress=${this.displayBufferedAmount}
+								>
+									<source src=${ifDefined(this.href)} />
+								</video>
+								<div class="discord-video-attachment-video-controls">
+									<div class="discord-media-attachment-controls" style="transform: translateY(0%)">
+										${/* eslint-disable lit-a11y/click-events-have-key-events */ html``}
+										<div
+											class="discord-media-attachment-video-button"
+											tabindex="0"
+											aria-label="${this.isPlaying ? 'Pause' : 'Play'}"
+											role="button"
+											@click=${this.handleClickPlayPauseIcon}
+										>
+											${/* eslint-enable lit-a11y/click-events-have-key-events */ html``}
+											${when(
+												this.isPlaying,
+												() => AudioVideoPauseIcon({ class: 'discord-media-attachment-control-icon' }),
+												() => AudioVideoPlayIcon({ class: 'discord-media-attachment-control-icon' })
+											)}
+										</div>
+										<div class="discord-media-attachment-duration-time-wrapper">
+											<span class="discord-media-attachment-duration-time-display">${this.currentPlaybackPosition}</span>
+											<span
+												class="discord-media-attachment-duration-time-display discord-media-attachment-duration-time-separator"
+												>/</span
+											>
+											<span class="discord-media-attachment-duration-time-display">${this.totalMediaDuration}</span>
+										</div>
+										<div class="discord-media-attachment-horizontal">
+											<div class="discord-media-attachment-media-bar-interaction">
+												<input
+													type="range"
+													${ref(this.seekSliderRef)}
+													class="discord-media-attachment-playback-control"
+													@input=${this.handleSeekSliderInput}
+													@change=${this.handleSeekSliderChange}
+													max="100"
+													value="0"
+												/>
+											</div>
+										</div>
+										<div class="discord-media-attachment-flex">
+											<div class="discord-media-attachment-flex-container">
+												<div ${ref(this.volumeControlRef)} class="discord-media-attachment-volume-button-slider">
+													<div
+														class="discord-media-attachment-volume-vertical"
+														@mouseenter=${this.handleVolumeVerticalEnter}
+														@mouseleave=${this.handleVolumeVerticalLeave}
+													>
+														<input
+															${ref(this.volumeControlInputRef)}
+															type="range"
+															class="discord-media-attachment-volume-slider"
+															@input=${this.handleVolumeSliderInput}
+															max="100"
+															value="100"
+														/>
+													</div>
+												</div>
+												<button
+													aria-label="Control volume"
+													type="button"
+													class="discord-media-attachment-volume-button"
+													@focus=${this.handleVolumeVerticalFocus}
+													@blur=${this.handleVolumeVerticalBlur}
+													@mouseover=${this.handleVolumeVerticalEnter}
+													@mouseout=${this.handleVolumeVerticalLeave}
+												>
+													${/* eslint-disable lit-a11y/click-events-have-key-events */ html``}
+													<div class="discord-media-attachment-volume-button-content" @click=${this.handleClickMuteIcon}>
+														${/* eslint-enable lit-a11y/click-events-have-key-events */ html``}
+														${when(
+															this.currentVolume === 0 || this.isMuted,
+															() =>
+																AudioVideoVolumeMutedIcon({
+																	class: 'discord-media-attachment-volume-button-control-icon'
+																}),
+															() =>
+																when(
+																	this.currentVolume <= 0.5,
+																	() =>
+																		AudioVideoVolumeBelow50PercentIcon({
+																			class: 'discord-media-attachment-volume-button-control-icon'
+																		}),
+																	() =>
+																		AudioVideoVolumeAbove50PercentIcon({
+																			class: 'discord-media-attachment-volume-button-control-icon'
+																		})
+																)
+														)}
+													</div>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+								<div class="discord-video-attachment-play-pause-pop">
+									${VideoPlayPausePopIcon({ class: 'discord-video-attachment-play-pause-pop-icon' })}
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'discord-video-attachment': DiscordVideoAttachment;
+	}
+}

--- a/packages/core/src/components/discord-video-attachment/DiscordVideoAttachment.ts
+++ b/packages/core/src/components/discord-video-attachment/DiscordVideoAttachment.ts
@@ -283,15 +283,14 @@ export class DiscordVideoAttachment extends DiscordMediaLifecycle implements Lig
 								</video>
 								<div class="discord-video-attachment-video-controls">
 									<div class="discord-media-attachment-controls" style="transform: translateY(0%)">
-										${/* eslint-disable lit-a11y/click-events-have-key-events */ html``}
 										<div
 											class="discord-media-attachment-video-button"
 											tabindex="0"
 											aria-label="${this.isPlaying ? 'Pause' : 'Play'}"
 											role="button"
 											@click=${this.handleClickPlayPauseIcon}
+											@keydown=${this.handleSpaceToPlayPause}
 										>
-											${/* eslint-enable lit-a11y/click-events-have-key-events */ html``}
 											${when(
 												this.isPlaying,
 												() => AudioVideoPauseIcon({ class: 'discord-media-attachment-control-icon' }),

--- a/packages/core/src/components/svgs/AudioVideoVolumeAbove50PercentIcon.ts
+++ b/packages/core/src/components/svgs/AudioVideoVolumeAbove50PercentIcon.ts
@@ -3,7 +3,7 @@ import { html, svg } from 'lit';
 
 const svgContent = svg`
 	<path fill="currentColor" d="M12 3a1 1 0 0 0-1-1h-.06a1 1 0 0 0-.74.32L5.92 7H3a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h2.92l4.28 4.68a1 1 0 0 0 .74.32H11a1 1 0 0 0 1-1V3ZM15.1 20.75c-.58.14-1.1-.33-1.1-.92v-.03c0-.5.37-.92.85-1.05a7 7 0 0 0 0-13.5A1.11 1.11 0 0 1 14 4.2v-.03c0-.6.52-1.06 1.1-.92a9 9 0 0 1 0 17.5Z"></path>
-	<path fill="currentColor" d="M15.16 16.51c-.57.28-1.16-.2-1.16-.83v-.14c0-.43.28-.8.63-1.02a3 3 0 0 0 0-5.04c-.35-.23-.63-.6-.63-1.02v-.14c0-.63.59-1.1 1.16-.83a5 5 0 0 1 0 9.02Z" class=""></path>
+	<path fill="currentColor" d="M15.16 16.51c-.57.28-1.16-.2-1.16-.83v-.14c0-.43.28-.8.63-1.02a3 3 0 0 0 0-5.04c-.35-.23-.63-.6-.63-1.02v-.14c0-.63.59-1.1 1.16-.83a5 5 0 0 1 0 9.02Z"></path>
 `;
 
 export default function AudioVideoVolumeAbove50PercentIcon(props: Record<string, unknown> = {}) {

--- a/packages/core/src/components/svgs/VideoFullScreenIcon.ts
+++ b/packages/core/src/components/svgs/VideoFullScreenIcon.ts
@@ -1,0 +1,10 @@
+import { spread } from '@open-wc/lit-helpers';
+import { html, svg } from 'lit';
+
+const svgContent = svg`
+	<path fill="currentColor" d="M4 6c0-1.1.9-2 2-2h3a1 1 0 0 0 0-2H6a4 4 0 0 0-4 4v3a1 1 0 0 0 2 0V6ZM4 18c0 1.1.9 2 2 2h3a1 1 0 1 1 0 2H6a4 4 0 0 1-4-4v-3a1 1 0 1 1 2 0v3ZM18 4a2 2 0 0 1 2 2v3a1 1 0 1 0 2 0V6a4 4 0 0 0-4-4h-3a1 1 0 1 0 0 2h3ZM20 18a2 2 0 0 1-2 2h-3a1 1 0 1 0 0 2h3a4 4 0 0 0 4-4v-3a1 1 0 1 0-2 0v3Z"></path>
+`;
+
+export default function VideoFullScreenIcon(props: Record<string, unknown> = {}) {
+	return html`<svg ${spread(props)} aria-hidden="true" role="img" width="24" height="24" fill="none" viewBox="0 0 24 24">${svgContent}</svg>`;
+}

--- a/packages/core/src/components/svgs/VideoPausePopIcon.ts
+++ b/packages/core/src/components/svgs/VideoPausePopIcon.ts
@@ -5,6 +5,6 @@ const svgContent = svg`
 	<path fill="currentColor" d="M6 4a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H6ZM15 4a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1h-3Z"></path>
 `;
 
-export default function VideoPlayPausePopIcon(props: Record<string, unknown> = {}) {
+export default function VideoPausePopIcon(props: Record<string, unknown> = {}) {
 	return html`<svg ${spread(props)} aria-hidden="true" role="img" width="16" height="16" fill="none" viewBox="0 0 24 24">${svgContent}</svg>`;
 }

--- a/packages/core/src/components/svgs/VideoPlayPausePopIcon.ts
+++ b/packages/core/src/components/svgs/VideoPlayPausePopIcon.ts
@@ -5,6 +5,6 @@ const svgContent = svg`
 	<path fill="currentColor" d="M6 4a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H6ZM15 4a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1h-3Z"></path>
 `;
 
-export default function AudioVideoPauseIcon(props: Record<string, unknown> = {}) {
+export default function VideoPlayPausePopIcon(props: Record<string, unknown> = {}) {
 	return html`<svg ${spread(props)} aria-hidden="true" role="img" width="16" height="16" fill="none" viewBox="0 0 24 24">${svgContent}</svg>`;
 }

--- a/packages/core/src/components/svgs/VideoPlayPopIcon.ts
+++ b/packages/core/src/components/svgs/VideoPlayPopIcon.ts
@@ -1,0 +1,10 @@
+import { spread } from '@open-wc/lit-helpers';
+import { html, svg } from 'lit';
+
+const svgContent = svg`
+	<path fill="currentColor" d="M9.25 3.35C7.87 2.45 6 3.38 6 4.96v14.08c0 1.58 1.87 2.5 3.25 1.61l10.85-7.04a1.9 1.9 0 0 0 0-3.22L9.25 3.35Z"></path>
+`;
+
+export default function VideoPlayPopIcon(props: Record<string, unknown> = {}) {
+	return html`<svg ${spread(props)} aria-hidden="true" role="img" width="16" height="16" fill="none" viewBox="0 0 24 24">${svgContent}</svg>`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export { DiscordThreadMessage } from './components/discord-thread-message/Discor
 export { DiscordTime } from './components/discord-time/DiscordTime.js';
 export { DiscordUnderlined } from './components/discord-underlined/DiscordUnderlined.js';
 export { DiscordUnorderedList } from './components/discord-unordered-list/DiscordUnorderedList.js';
+export { DiscordVideoAttachment } from './components/discord-video-attachment/DiscordVideoAttachment.js';
 
 /* EXPORTS END */
 export { getConfig, setConfig } from './config.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -41,6 +41,7 @@ export const DiscordThreadMessage = createReactComponent('discord-thread-message
 export const DiscordTime = createReactComponent('discord-time', ReactComponents.DiscordTime);
 export const DiscordUnderlined = createReactComponent('discord-underlined', ReactComponents.DiscordUnderlined);
 export const DiscordUnorderedList = createReactComponent('discord-unordered-list', ReactComponents.DiscordUnorderedList);
+export const DiscordVideoAttachment = createReactComponent('discord-video-attachment', ReactComponents.DiscordVideoAttachment);
 
 /* IMPORTS END */
 


### PR DESCRIPTION
fixed #410

TODO: 
- [x] The progress bar currently does not show proper progress, the calculation is off somewhere. Also affects audio component.
- [x] The video attachment code needs to be moved to the proper place in the demo file when the above issue is resolved
- [x] The eslint disable issues need to be resolved by way of adding keydown events (space to play/pause and mute/unmute)
- [x] It has to be possible to play/pause by clicking the video area
- [ ] The play pause pop animation should play