### PR TITLE
Fixing User Image and Message Alignment Issue

### DIFF
--- a/packages/core/src/components/discord-embed/DiscordEmbed.ts
+++ b/packages/core/src/components/discord-embed/DiscordEmbed.ts
@@ -95,6 +95,8 @@ export class DiscordEmbed extends LitElement implements DiscordEmbedProps, Light
 			grid-column: 1 / 1;
 			margin-top: 8px;
 			min-width: 0;
+   			max-width: 100%;
+	  		display: block;
 		}
 
 		:host([light-theme]) .discord-embed-author {

--- a/packages/core/src/components/discord-embed/DiscordEmbed.ts
+++ b/packages/core/src/components/discord-embed/DiscordEmbed.ts
@@ -323,18 +323,20 @@ export class DiscordEmbed extends LitElement implements DiscordEmbedProps, Light
 							emojiParsedAuthorName,
 							() =>
 								html`<div class="discord-embed-author">
-									${when(
-										this.authorImage,
-										() => html`<img src=${ifDefined(this.authorImage)} alt="" class="discord-author-image" />`
-									)}
-									${when(
-										this.authorUrl,
-										() =>
-											html`<a href=${ifDefined(this.authorUrl)} target="_blank" rel="noopener noreferrer">
-												${emojiParsedAuthorName}
-											</a>`,
-										() => html`${emojiParsedAuthorName}`
-									)}
+										<div style="display:flex; alig-items:center;">
+		  									${when(
+												this.authorImage,
+												() => html`<img src=${ifDefined(this.authorImage)} alt="" class="discord-author-image" />`
+											)}
+											${when(
+												this.authorUrl,
+												() =>
+													html`<a href=${ifDefined(this.authorUrl)} target="_blank" rel="noopener noreferrer">
+														${emojiParsedAuthorName}
+													</a>`,
+												() => html`${emojiParsedAuthorName}`
+											)}
+		  								</ div>
 								</div>`
 						)}
 						${when(

--- a/packages/core/src/components/discord-message/DiscordMessage.ts
+++ b/packages/core/src/components/discord-message/DiscordMessage.ts
@@ -41,7 +41,7 @@ export class DiscordMessage extends LitElement implements DiscordMessageProps, L
 
 		.discord-message-inner {
 			display: flex;
-			align-items: center;
+			align-items: start;
 			position: relative;
 			-webkit-box-flex: 0;
 			-ms-flex: 0 0 auto;


### PR DESCRIPTION
The "align-items" was set to "center" instead of "start" causing it to be misaligned