### PR TITLE
fix: add skiping one line

### DIFF
--- a/packages/core/src/components/discord-embed/DiscordEmbed.ts
+++ b/packages/core/src/components/discord-embed/DiscordEmbed.ts
@@ -423,7 +423,7 @@ export class DiscordEmbed extends LitElement implements DiscordEmbedProps, Light
 
 		return el.map((wordOrHtmlTemplate) => {
 			if (typeof wordOrHtmlTemplate === 'string') {
-				return html`<span>${wordOrHtmlTemplate}</span>`;
+				return html`<div><span>${wordOrHtmlTemplate}</span></div>`;
 			}
 
 			return wordOrHtmlTemplate;

--- a/packages/core/src/components/discord-embed/DiscordEmbed.ts
+++ b/packages/core/src/components/discord-embed/DiscordEmbed.ts
@@ -423,7 +423,7 @@ export class DiscordEmbed extends LitElement implements DiscordEmbedProps, Light
 
 		return el.map((wordOrHtmlTemplate) => {
 			if (typeof wordOrHtmlTemplate === 'string') {
-				return html`<div><span>${wordOrHtmlTemplate}</span></div>`;
+				return html`<div>${wordOrHtmlTemplate}</div>`;
 			}
 
 			return wordOrHtmlTemplate;


### PR DESCRIPTION
I don't know if there is any problem in having the tag "div" but without it when the person uses it skips only one line it does not skip and when it skips two it skips one then it goes back to normal