### PR TITLE
fix(discord-reply): Removed rouge closing curly brace

### DIFF
--- a/packages/core/src/components/discord-reply/DiscordReply.ts
+++ b/packages/core/src/components/discord-reply/DiscordReply.ts
@@ -347,7 +347,7 @@ export class DiscordReply extends LitElement implements LightTheme {
 						this.command,
 						() => CommandReply({ class: 'discord-replied-message-content-icon' }),
 						() => when(this.attachment, () => AttachmentReply({ class: 'discord-replied-message-content-icon' }))
-					)}}`
+					)}`
 		)}`;
 	}
 }


### PR DESCRIPTION
## Description
Rouge `}` shown when using the following code:
```jsx
<DiscordReply
    slot="reply"
    profile="you"
    author="You"
    avatar="./Logo.svg"
    roleColor="#1e88e5"
    bot={true}
    verified={true}
    command={true}
  >
      <p>Click to see command</p>
</DiscordReply>
```

## Screenshots
![example of rouge curly brace](https://github.com/user-attachments/assets/80c74306-d5e1-4252-a89b-8a558d84393d)
