### PR TITLE
fix(discord-action-row): wrap using "flex-wrap"

### DIFF
--- a/packages/core/src/components/discord-action-row/DiscordActionRow.ts
+++ b/packages/core/src/components/discord-action-row/DiscordActionRow.ts
@@ -9,7 +9,7 @@ export class DiscordActionRow extends LitElement {
 	public static override readonly styles = css`
 		:host {
 			display: flex;
-			flex-wrap: nowrap;
+			flex-wrap: wrap;
 		}
 	`;
 


### PR DESCRIPTION
The "flex-wrap" was wrong causing the buttons to always stay on the same line and making them lose responsiveness, taking into account that the discord itself is the way I left it, I recommend leaving it like this