### PR TITLE
fix: remove border on modal input

### DIFF
--- a/packages/core/src/components/discord-input-text/DiscordInputText.ts
+++ b/packages/core/src/components/discord-input-text/DiscordInputText.ts
@@ -55,7 +55,7 @@ export class DiscordInputText extends LitElement {
 			height: 83px;
 			padding: 8px 38.92px 8px 8px;
 			border-radius: 3px;
-			border: 1px solid #b0b5bc;
+			border: medium;
 			background-color: #1e1f22;
 			color: #b0b5bc;
 			font-family: 'gg sans', 'Noto Sans', Whitney, 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
@@ -68,7 +68,7 @@ export class DiscordInputText extends LitElement {
 			height: 40px;
 			padding: 8px 38.92px 8px 8px;
 			border-radius: 3px;
-			border: 1px solid #b0b5bc;
+			border: medium;
 			background-color: #1e1f22;
 			color: #b0b5bc;
 			font-family: 'gg sans', 'Noto Sans', Whitney, 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
@@ -127,6 +127,7 @@ export class DiscordInputText extends LitElement {
 		:host([light-theme]) .discord-text-input-paragraph,
 		:host([light-theme]) .discord-text-input-short {
 			background-color: rgb(253, 253, 253);
+			border: 1px solid #b0b5bc;
 		}
 
 		:host([light-theme]) input,


### PR DESCRIPTION
The new modal component had a slight issue with the bordercolor always being there instead of only on the light mode version. This pull request edits that to make it more inline with discords official style.

Before:

![image](https://github.com/user-attachments/assets/9307673b-6c8f-4882-b74c-9d515badd344)

After:

![image](https://github.com/user-attachments/assets/b3aa4379-c5fd-4109-8798-fa57239fc166)
