### PR TITLE
feat(markdown): add subtext

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -175,6 +175,9 @@
 					<discord-message profile="favna">
 						<discord-quote>I am quoted text!</discord-quote>
 					</discord-message>
+					<discord-message profile="dominik">
+						<discord-subtext>I am subtext!</discord-subtext>
+					</discord-message>
 				</discord-messages>
 				<h3 class="title">No Background mode</h3>
 				<discord-messages no-background>

--- a/packages/core/demo/index.js
+++ b/packages/core/demo/index.js
@@ -24,6 +24,11 @@ globalThis.$discordMessage = {
 			roleIcon: 'https://raw.githubusercontent.com/skyra-project/discord-components-implementations/main/shared/public/booster.png',
 			roleName: 'Booster'
 		},
+		dominik: {
+			author: 'Dominik',
+			avatar: 'https://github.com/mezotv.png',
+			roleColor: '#26d1a3'
+		},
 		discordjs: {
 			author: 'Discord.js Official #announcements',
 			avatar: 'https://raw.githubusercontent.com/skyra-project/discord-components-implementations/main/shared/public/discordjs.png',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
 		"./discord-audio-attachment.js": "./dist/components/discord-audio-attachment/DiscordAudioAttachment.js",
 		"./discord-author-info.js": "./dist/components/discord-author-info/DiscordAuthorInfo.js",
 		"./discord-bold.js": "./dist/components/discord-bold/DiscordBold.js",
+		"./discord-subtext.js": "./dist/components/discord-subtext/DiscordSubtext.js",
 		"./discord-button.js": "./dist/components/discord-button/DiscordButton.js",
 		"./discord-code.js": "./dist/components/discord-code/DiscordCode.js",
 		"./discord-command.js": "./dist/components/discord-command/DiscordCommand.js",

--- a/packages/core/src/components/discord-subtext/DiscordSubtext.ts
+++ b/packages/core/src/components/discord-subtext/DiscordSubtext.ts
@@ -1,0 +1,28 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('discord-subtext')
+export class DiscordSubtext extends LitElement {
+	/**
+	 * @internal
+	 */
+	public static override readonly styles = css`
+		:host > small {
+			color: #949ba4;
+		}
+	`;
+
+	protected override render() {
+		return html`
+			<small>
+				<slot></slot>
+			</small>
+		`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'discord-subtext': DiscordSubtext;
+	}
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export { DiscordAttachments } from './components/discord-attachments/DiscordAtta
 export { DiscordAudioAttachment } from './components/discord-audio-attachment/DiscordAudioAttachment.js';
 export { DiscordAuthorInfo } from './components/discord-author-info/DiscordAuthorInfo.js';
 export { DiscordBold } from './components/discord-bold/DiscordBold.js';
+export { DiscordSubtext } from './components/discord-subtext/DiscordSubtext.js';
 export { DiscordButton } from './components/discord-button/DiscordButton.js';
 export { DiscordCode } from './components/discord-code/DiscordCode.js';
 export { DiscordCommand } from './components/discord-command/DiscordCommand.js';

--- a/packages/documentation/astro.config.mts
+++ b/packages/documentation/astro.config.mts
@@ -466,6 +466,11 @@ export default defineConfig({
 									roleIcon: 'https://raw.githubusercontent.com/skyra-project/discord-components-implementations/main/shared/public/booster.png',
 									roleName: 'Booster'
 								},
+								dominik: {
+									author: 'Dominik',
+									avatar: 'https://github.com/mezotv.png',
+									roleColor: '#26d1a3',
+								},
 								discordjs: {
 									author: 'Discord.js Official #announcements',
 									avatar: 'https://raw.githubusercontent.com/skyra-project/discord-components-implementations/main/shared/public/discordjs.png',

--- a/packages/documentation/src/lit/components/DiscordComponentsWrapper.ts
+++ b/packages/documentation/src/lit/components/DiscordComponentsWrapper.ts
@@ -160,6 +160,9 @@ export class DiscordComponentsWrapper extends LitElement {
 					<discord-message profile="favna">
 						<discord-quote>I am quoted text!</discord-quote>
 					</discord-message>
+					<discord-message profile="dominik">
+						<discord-subtext>I am subtext!</discord-subtext>
+					</discord-message>
 				</discord-messages>
 				<h3 class="title">No Background mode</h3>
 				<discord-messages no-background>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,7 @@ export const DiscordAttachments = createReactComponent('discord-attachments', Re
 export const DiscordAudioAttachment = createReactComponent('discord-audio-attachment', ReactComponents.DiscordAudioAttachment);
 export const DiscordAuthorInfo = createReactComponent('discord-author-info', ReactComponents.DiscordAuthorInfo);
 export const DiscordBold = createReactComponent('discord-bold', ReactComponents.DiscordBold);
+export const DiscordSubtext = createReactComponent('discord-subtext', ReactComponents.DiscordSubtext);
 export const DiscordButton = createReactComponent('discord-button', ReactComponents.DiscordButton);
 export const DiscordCode = createReactComponent('discord-code', ReactComponents.DiscordCode);
 export const DiscordCommand = createReactComponent('discord-command', ReactComponents.DiscordCommand);


### PR DESCRIPTION
This adds support for discords new subtext markdown feature by creating a new discord-subtext tag.

![image](https://github.com/user-attachments/assets/a92043af-1c77-488f-ba2a-04cd15f6e20b)
