### PR TITLE
fix: Correcting the line style that indicates the thread

### DIFF
--- a/packages/core/src/components/discord-message/DiscordMessage.ts
+++ b/packages/core/src/components/discord-message/DiscordMessage.ts
@@ -217,7 +217,7 @@ export class DiscordMessage extends LitElement implements LightTheme {
 		:host([has-thread]):after {
 			width: 2rem;
 			left: 2.2rem;
-			top: 1.75rem;
+			top: 4.8rem;
 			border-left: 2px solid #4f545c;
 			border-bottom: 2px solid #4f545c;
 			border-bottom-left-radius: 8px;


### PR DESCRIPTION
Before the line went beyond the user's avatar of the message is now correct

Before:
![image](https://github.com/user-attachments/assets/536b7773-ecb1-4589-8d0a-a7c54735682a)

Now:
![image](https://github.com/user-attachments/assets/6368d378-979d-418c-b431-1207664a70bd)

The oficial of discord:
![image](https://github.com/user-attachments/assets/97bbe43c-60ed-4df6-adec-04bd286ce300)

