### PR TITLE
fix: prevent timestamp wrapping

### DIFF
--- a/packages/core/src/components/discord-time/DiscordTime.ts
+++ b/packages/core/src/components/discord-time/DiscordTime.ts
@@ -8,6 +8,7 @@ export class DiscordTime extends LitElement {
 	 */
 	public static override readonly styles = css`
 		:host {
+			white-space: nowrap;
 			background-color: #ffffff0f;
 			border-radius: 3px;
 			padding: 0 2px;


### PR DESCRIPTION
Discord doesnt have wrapping on timestamps, so this ensures no wrapping.