### PR TITLE
fix: correcting context-user-name-color

### DIFF
--- a/packages/core/src/components/discord-command/DiscordCommand.ts
+++ b/packages/core/src/components/discord-command/DiscordCommand.ts
@@ -78,7 +78,7 @@ export class DiscordCommand extends LitElement implements LightTheme {
 			}
 
 			:host([light-theme]) .discord-replied-message-username {
-				color: rgb(46, 51, 56) !important;
+				color: rgb(46, 51, 56);
 			}
 
 			:host([compact-mode]) .discord-context-user {

--- a/packages/core/src/components/discord-command/DiscordCommand.ts
+++ b/packages/core/src/components/discord-command/DiscordCommand.ts
@@ -77,6 +77,10 @@ export class DiscordCommand extends LitElement implements LightTheme {
 				margin-right: 0;
 			}
 
+			:host([light-theme]) .discord-replied-message-username {
+				color: rgb(46, 51, 56) !important;
+			}
+
 			:host([compact-mode]) .discord-context-user {
 				display: flex;
 				align-items: center;


### PR DESCRIPTION
I only realized now that the context user name is the wrong color in light mode