### PR TITLE
fix: inline field bug in Discord embed

### DIFF
--- a/packages/core/src/components/discord-embed-field/DiscordEmbedField.ts
+++ b/packages/core/src/components/discord-embed-field/DiscordEmbedField.ts
@@ -74,7 +74,7 @@ export class DiscordEmbedField extends LitElement implements LightTheme {
 	 * @defaultValue 1
 	 */
 	@property({ type: Number, reflect: true, attribute: 'inline-index' })
-	public accessor inlineIndex = 1;
+	public accessor inlineIndex: number | undefined = undefined;
 
 	@consume({ context: messagesLightTheme, subscribe: true })
 	@property({ type: Boolean, reflect: true, attribute: 'light-theme' })
@@ -83,7 +83,7 @@ export class DiscordEmbedField extends LitElement implements LightTheme {
 	private readonly validInlineIndices = new Set([1, 2, 3]);
 
 	public checkInlineIndex() {
-		if (this.inline && this.inlineIndex) {
+		if (this.inlineIndex) {
 			const inlineIndexAsNumber = Number(this.inlineIndex);
 			if (!Number.isNaN(inlineIndexAsNumber) && !this.validInlineIndices.has(inlineIndexAsNumber)) {
 				throw new RangeError('DiscordEmbedField `inlineIndex` prop must be one of: 1, 2, or 3');

--- a/packages/core/src/components/discord-embed-field/DiscordEmbedField.ts
+++ b/packages/core/src/components/discord-embed-field/DiscordEmbedField.ts
@@ -83,7 +83,7 @@ export class DiscordEmbedField extends LitElement implements LightTheme {
 	private readonly validInlineIndices = new Set([1, 2, 3]);
 
 	public checkInlineIndex() {
-		if (this.inlineIndex) {
+		if (this.inline && this.inlineIndex) {
 			const inlineIndexAsNumber = Number(this.inlineIndex);
 			if (!Number.isNaN(inlineIndexAsNumber) && !this.validInlineIndices.has(inlineIndexAsNumber)) {
 				throw new RangeError('DiscordEmbedField `inlineIndex` prop must be one of: 1, 2, or 3');

--- a/packages/core/src/components/discord-embed-fields/DiscordEmbedFields.ts
+++ b/packages/core/src/components/discord-embed-fields/DiscordEmbedFields.ts
@@ -25,10 +25,6 @@ export class DiscordEmbedFields extends LitElement {
 		::slotted([inline-index='3']) {
 			grid-column: 9/13 !important;
 		}
-
-		::slotted(:not([inline])) {
-			grid-column: 1/13 !important;
-		}
 	`;
 
 	protected override render() {

--- a/packages/core/src/components/discord-embed-fields/DiscordEmbedFields.ts
+++ b/packages/core/src/components/discord-embed-fields/DiscordEmbedFields.ts
@@ -25,6 +25,10 @@ export class DiscordEmbedFields extends LitElement {
 		::slotted([inline-index='3']) {
 			grid-column: 9/13 !important;
 		}
+
+		::slotted(:not([inline])) {
+			grid-column: 1/13 !important;
+		}
 	`;
 
 	protected override render() {


### PR DESCRIPTION
Fixes #509

Fix the issue with the bottom field not spanning across three inline fields in the embed.