### PR TITLE
feat: added option to add the channel name above discord messages

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -53,7 +53,7 @@
 
 			<main id="demo">
 				<h3 class="title">A normal conversation</h3>
-				<discord-messages channel-name="General" type="channel">
+				<discord-messages channel-name="General" channel-type="text">
 					<discord-message author="Alyx Vargas"> Hey guys, I'm new here! Glad to be able to join you all! </discord-message>
 					<discord-message
 						author="Fenton Smart"

--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -53,7 +53,7 @@
 
 			<main id="demo">
 				<h3 class="title">A normal conversation</h3>
-				<discord-messages>
+				<discord-messages channel-name="General" type="channel">
 					<discord-message author="Alyx Vargas"> Hey guys, I'm new here! Glad to be able to join you all! </discord-message>
 					<discord-message
 						author="Fenton Smart"

--- a/packages/core/src/components/discord-messages/DiscordMessages.ts
+++ b/packages/core/src/components/discord-messages/DiscordMessages.ts
@@ -113,8 +113,8 @@ export class DiscordMessages extends LitElement implements LightTheme {
 	public accessor compactMode = false;
 
 	/**
-	 * The type of mention this should be. This will prepend the proper prefix character.
-	 * Valid values: `user`, `channel`, `role`, `voice`, `locked`, `thread`, `forum`, and `slash`.
+	 * The type of channel this should be. This will prepend the proper prefix character.
+	 * Valid values: `channel`, `forum`, `locked`, `thread`, and `voice`.
 	 */
 	@property({ reflect: true, attribute: 'type' })
 	public accessor type: 'channel' | 'forum' | 'locked' | 'thread' | 'voice';
@@ -164,7 +164,7 @@ export class DiscordMessages extends LitElement implements LightTheme {
 						<div class="discord-channel-icon">${channelIcon}</div>
 						<div class="discord-channel-name">${this.name}</div>
 					</div>`
-				: ''}
+				: null}
 			<slot></slot>
 		</div>`;
 	}

--- a/packages/core/src/components/discord-messages/DiscordMessages.ts
+++ b/packages/core/src/components/discord-messages/DiscordMessages.ts
@@ -114,14 +114,18 @@ export class DiscordMessages extends LitElement implements LightTheme {
 	public accessor compactMode = false;
 
 	/**
-	 * The type of channel this should be. This will prepend the proper prefix character.
-	 * Valid values: `channel`, `forum`, `locked`, `thread`, and `voice`.
+	 * The type of channel this should be, this will be displayed above the message and only applies if {@link DiscordMessages.channelName} is set.
+	 * Valid values are: `text`, `forum`, `locked`, `thread`, and `voice`.
 	 */
-	@property({ reflect: true, attribute: 'type' })
-	public accessor type: 'channel' | 'forum' | 'locked' | 'thread' | 'voice';
+	@property({ reflect: true, attribute: 'channel-type' })
+	public accessor channelType: 'forum' | 'locked' | 'text' | 'thread' | 'voice';
+
+	/**
+	 * The name of the channel, this will be displayed above the message and only applies if {@link DiscordMessages.channelType} is set.
+	 */
 
 	@property({ reflect: true, attribute: 'channel-name' })
-	public accessor name: string;
+	public accessor channelName: string;
 
 	public override connectedCallback(): void {
 		super.connectedCallback();
@@ -141,8 +145,8 @@ export class DiscordMessages extends LitElement implements LightTheme {
 
 	protected override render() {
 		let channelIcon: ReturnType<typeof html>;
-		switch (this.type) {
-			case 'channel':
+		switch (this.channelType) {
+			case 'text':
 				channelIcon = html`${ChannelIcon()}`;
 				break;
 			case 'voice':
@@ -161,11 +165,11 @@ export class DiscordMessages extends LitElement implements LightTheme {
 
 		return html`
 			${when(
-				this.type && this.name,
+				this.channelType && this.channelName,
 				() =>
 					html`<div class="discord-channel-header">
 						<div class="discord-channel-icon">${channelIcon}</div>
-						<div class="discord-channel-name">${this.name}</div>
+						<div class="discord-channel-name">${this.channelName}</div>
 					</div>`
 			)}
 			<slot></slot>

--- a/packages/core/src/components/discord-messages/DiscordMessages.ts
+++ b/packages/core/src/components/discord-messages/DiscordMessages.ts
@@ -3,6 +3,11 @@ import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { defaultBackground, defaultMode, defaultTheme } from '../../config.js';
 import type { LightTheme } from '../../types.js';
+import ChannelForum from '../svgs/ChannelForum.js';
+import ChannelIcon from '../svgs/ChannelIcon.js';
+import ChannelThread from '../svgs/ChannelThread.js';
+import LockedVoiceChannel from '../svgs/LockedVoiceChannel.js';
+import VoiceChannel from '../svgs/VoiceChannel.js';
 
 export const messagesLightTheme = createContext<boolean>('light-theme');
 export const messagesCompactMode = createContext<boolean>('compact-mode');
@@ -55,6 +60,35 @@ export class DiscordMessages extends LitElement implements LightTheme {
 			margin-bottom: 0.5rem;
 			border-bottom-width: 0;
 		}
+
+		:host .discord-channel-header {
+			display: flex;
+			align-items: center;
+			padding: 0.5rem 1rem;
+			box-shadow:
+				0 2px 0 0 rgba(0, 0, 0, 0.05),
+				0 1.5px 0 0 rgba(0, 0, 0, 0.05),
+				0 1px 0 0 rgba(0, 0, 0, 0.16);
+		}
+
+		:host .discord-channel-icon {
+			height: 24px;
+			width: auto;
+			margin: 0 8px;
+			position: relative;
+			flex: 0 0 auto;
+			color: #80848e;
+		}
+
+		:host([light-theme]) .discord-channel-icon {
+			color: #6d6f78;
+		}
+
+		:host .discord-channel-name {
+			margin: 0 8px 0 0;
+			flex: 0 0 auto;
+			min-width: auto;
+		}
 	`;
 
 	/**
@@ -78,6 +112,16 @@ export class DiscordMessages extends LitElement implements LightTheme {
 	@property({ type: Boolean, reflect: true, attribute: 'compact-mode' })
 	public accessor compactMode = false;
 
+	/**
+	 * The type of mention this should be. This will prepend the proper prefix character.
+	 * Valid values: `user`, `channel`, `role`, `voice`, `locked`, `thread`, `forum`, and `slash`.
+	 */
+	@property({ reflect: true, attribute: 'type' })
+	public accessor type: 'channel' | 'forum' | 'locked' | 'thread' | 'voice';
+
+	@property({ reflect: true, attribute: 'channel-name' })
+	public accessor name: string;
+
 	public override connectedCallback(): void {
 		super.connectedCallback();
 
@@ -95,7 +139,34 @@ export class DiscordMessages extends LitElement implements LightTheme {
 	}
 
 	protected override render() {
-		return html`<slot></slot>`;
+		let channelIcon: ReturnType<typeof html>;
+		switch (this.type) {
+			case 'channel':
+				channelIcon = html`${ChannelIcon()}`;
+				break;
+			case 'voice':
+				channelIcon = html`${VoiceChannel()}`;
+				break;
+			case 'locked':
+				channelIcon = html`${LockedVoiceChannel()}`;
+				break;
+			case 'thread':
+				channelIcon = html`${ChannelThread()}`;
+				break;
+			case 'forum':
+				channelIcon = html`${ChannelForum()}`;
+				break;
+		}
+
+		return html`<div>
+			${this.type && this.name
+				? html`<div class="discord-channel-header">
+						<div class="discord-channel-icon">${channelIcon}</div>
+						<div class="discord-channel-name">${this.name}</div>
+					</div>`
+				: ''}
+			<slot></slot>
+		</div>`;
 	}
 }
 

--- a/packages/core/src/components/discord-messages/DiscordMessages.ts
+++ b/packages/core/src/components/discord-messages/DiscordMessages.ts
@@ -1,6 +1,7 @@
 import { createContext, provide } from '@lit/context';
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { when } from 'lit/directives/when.js';
 import { defaultBackground, defaultMode, defaultTheme } from '../../config.js';
 import type { LightTheme } from '../../types.js';
 import ChannelForum from '../svgs/ChannelForum.js';
@@ -158,15 +159,17 @@ export class DiscordMessages extends LitElement implements LightTheme {
 				break;
 		}
 
-		return html`<div>
-			${this.type && this.name
-				? html`<div class="discord-channel-header">
+		return html`
+			${when(
+				this.type && this.name,
+				() =>
+					html`<div class="discord-channel-header">
 						<div class="discord-channel-icon">${channelIcon}</div>
 						<div class="discord-channel-name">${this.name}</div>
 					</div>`
-				: null}
+			)}
 			<slot></slot>
-		</div>`;
+		`;
 	}
 }
 


### PR DESCRIPTION
Allows the `discord-messages` element to accept `channel` and `type` props which adds a header above the messages.

Example: 
![image](https://github.com/user-attachments/assets/8f8ffe98-0879-49a1-a5ba-e11c2e099670)

